### PR TITLE
lib: add memory access functions to env header

### DIFF
--- a/include/librpmi_env.h
+++ b/include/librpmi_env.h
@@ -81,6 +81,27 @@ static inline void *rpmi_env_memcpy(void *dest, const void *src, rpmi_size_t n)
 }
 
 /**
+ * @brief Write a hw memory range with buffer
+ *
+ * @param[in] dest 	destination hw address
+ * @param[in] buf 	buffer pinter
+ * @param[in] n 	number of bytes to write
+ * @return void *	Pointer to destination
+ */
+void *rpmi_env_mem_write(char *dest, const void *buf, rpmi_size_t n);
+
+
+/**
+ * @brief read a hw memory range to buffer
+ *
+ * @param[in] src 	srour hw address
+ * @param[in] buf 	buffer pinter
+ * @param[in] n 	number of bytes to write
+ * @return void *	Pointer to destination
+ */
+void *rpmi_env_mem_read(const void *src, char* buf, rpmi_size_t n);
+
+/**
  * @brief Write or fill a memory range with a character
  *
  * @param[in] dest 	pointer to destination
@@ -94,7 +115,7 @@ static inline void *rpmi_env_memset(void *dest, int c, rpmi_size_t n)
 
 	while (n > 0) {
 		n--;
-		*temp++ = c;
+		rpmi_env_mem_write(temp++, &c, 1);
 	}
 
 	return dest;


### PR DESCRIPTION
in environments where one of the memcpy address argumnets can be a hardware address, so replaced the calls to memcpy with mem_read/write() calls where environment specific memory red/write operations can be implemented.

rpmi_shmem_simple_read/write() routines now use rpmi_env_mem_read/write() instead of memcpy().