### PR TITLE
librpmi fix hsm and suspend issues

### DIFF
--- a/lib/rpmi_service_group_hsm.c
+++ b/lib/rpmi_service_group_hsm.c
@@ -214,8 +214,8 @@ static enum rpmi_error rpmi_hsm_sg_get_suspend_types(struct rpmi_service_group *
 
 	*response_datalen = (returned + 3) * sizeof(*resp);
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)status);
-	resp[1] = rpmi_to_xe32(trans->is_be, returned);
-	resp[2] = rpmi_to_xe32(trans->is_be, remaining);
+	resp[1] = rpmi_to_xe32(trans->is_be, remaining);
+	resp[2] = rpmi_to_xe32(trans->is_be, returned);
 
 	return RPMI_SUCCESS;
 }

--- a/lib/rpmi_service_group_sysreset.c
+++ b/lib/rpmi_service_group_sysreset.c
@@ -79,8 +79,8 @@ static enum rpmi_error rpmi_sysreset_do_reset(struct rpmi_service_group *group,
 
 	sysreset_type = rpmi_sysreset_find_type(sgrst, reset_type);
 	if (sysreset_type) {
+		DPRINTF("%s: Entering platform sysreset ..\n", __func__);
 		sgrst->ops->do_system_reset(sgrst->ops_priv, reset_type);
-		while (1) ;
 	}
 
 	*response_datalen = sizeof(*resp);


### PR DESCRIPTION
- in rpmi_context_process_a2p_request() removed data length check as in cases like suspend types inquiry this check is invalid
- in rpmi_sysreset_do_reset(), while(1) was stopping the reboot by making qemu not releasing the Big Quemu Lock.