### PR TITLE
lib: Optimize the definition of rpmi_hsm

### DIFF
--- a/lib/rpmi_hsm.c
+++ b/lib/rpmi_hsm.c
@@ -33,42 +33,44 @@ struct rpmi_hsm {
 	/** Whether HSM instance is non-leaf (or hierarchical) instance */
 	rpmi_bool_t is_non_leaf;
 
-	/** Details required by leaf instance */
-	struct {
-		/** Number of harts */
-		rpmi_uint32_t hart_count;
+	union {
+		/** Details required by leaf instance */
+		struct {
+			/** Number of harts */
+			rpmi_uint32_t hart_count;
 
-		/** Array of hart IDs */
-		const rpmi_uint32_t *hart_ids;
+			/** Array of hart IDs */
+			const rpmi_uint32_t *hart_ids;
 
-		/** Array of harts */
-		struct rpmi_hsm_hart *harts;
+			/** Array of harts */
+			struct rpmi_hsm_hart *harts;
 
-		/** Number of suspend types */
-		rpmi_uint32_t suspend_type_count;
+			/** Number of suspend types */
+			rpmi_uint32_t suspend_type_count;
 
-		/** Array of suspend types */
-		const struct rpmi_hsm_suspend_type *suspend_types;
+			/** Array of suspend types */
+			const struct rpmi_hsm_suspend_type *suspend_types;
 
-		/**
-		 * Platform HSM operations
-		 *
-		 * Note: These operations are called with harts[i]->lock held
-		 */
-		const struct rpmi_hsm_platform_ops *ops;
+			/**
+			 * Platform HSM operations
+			 *
+			 * Note: These operations are called with harts[i]->lock held
+			 */
+			const struct rpmi_hsm_platform_ops *ops;
 
-		/** Private data of platform HSM operations */
-		void *ops_priv;
-	} leaf;
+			/** Private data of platform HSM operations */
+			void *ops_priv;
+		} leaf;
 
-	/** Details required by non-leaf instance */
-	struct {
-		/** Number of child instances */
-		rpmi_uint32_t child_count;
+		/** Details required by non-leaf instance */
+		struct {
+			/** Number of child instances */
+			rpmi_uint32_t child_count;
 
-		/** Array of child instance pointers */
-		struct rpmi_hsm **child_array;
-	} nonleaf;
+			/** Array of child instance pointers */
+			struct rpmi_hsm **child_array;
+		} nonleaf;
+	};
 };
 
 rpmi_uint32_t rpmi_hsm_hart_count(struct rpmi_hsm *hsm)


### PR DESCRIPTION
rpmi_hsm.leaf and rmpi_hsm.noleaf can be put into a union to save memory