### PR TITLE
lib: clock service group fixes

### DIFF
--- a/lib/rpmi_service_group_clock.c
+++ b/lib/rpmi_service_group_clock.c
@@ -841,7 +841,7 @@ rpmi_service_group_clock_create(rpmi_uint32_t clock_count,
 						 ops,
 						 ops_priv);
 	if (!clkgrp->clock_tree) {
-		DPRINTF("%s: failed to initialize clock tree\n");
+		DPRINTF("%s: failed to initialize clock tree\n", __func__);
 		rpmi_env_free(clkgrp);
 		return NULL;
 	}

--- a/lib/rpmi_service_group_clock.c
+++ b/lib/rpmi_service_group_clock.c
@@ -442,7 +442,7 @@ rpmi_clock_sg_get_attributes(struct rpmi_service_group *group,
 	rpmi_uint32_t clkid = rpmi_to_xe32(trans->is_be,
 				((const rpmi_uint32_t *)request_data)[0]);
 
-	if (clkid > clkgrp->clock_count) {
+	if (clkid >= clkgrp->clock_count) {
 		resp_dlen = sizeof(*resp);
 		resp[0] = rpmi_to_xe32(trans->is_be,
 					(rpmi_uint32_t)RPMI_ERR_NOTFOUND);
@@ -496,7 +496,7 @@ rpmi_clock_sg_get_supp_rates(struct rpmi_service_group *group,
 	rpmi_uint32_t clkid = rpmi_to_xe32(trans->is_be,
 				((const rpmi_uint32_t *)request_data)[0]);
 
-	if (clkid > clkgrp->clock_count) {
+	if (clkid >= clkgrp->clock_count) {
 		resp_dlen = sizeof(*resp);
 		resp[0] = rpmi_to_xe32(trans->is_be,
 				       (rpmi_uint32_t)RPMI_ERR_NOTFOUND);
@@ -598,7 +598,7 @@ rpmi_clock_sg_set_config(struct rpmi_service_group *group,
 	rpmi_uint32_t clkid = rpmi_to_xe32(trans->is_be,
 			       ((const rpmi_uint32_t *)request_data)[0]);
 
-	if (clkid > clkgrp->clock_count) {
+	if (clkid >= clkgrp->clock_count) {
 		resp[0] = rpmi_to_xe32(trans->is_be,
 				       (rpmi_uint32_t)RPMI_ERR_NOTFOUND);
 		goto done;
@@ -644,7 +644,7 @@ rpmi_clock_sg_get_config(struct rpmi_service_group *group,
 	rpmi_uint32_t clkid = rpmi_to_xe32(trans->is_be,
 				     ((const rpmi_uint32_t *)request_data)[0]);
 
-	if (clkid > clkgrp->clock_count) {
+	if (clkid >= clkgrp->clock_count) {
 		resp[0] = rpmi_to_xe32(trans->is_be,
 				       (rpmi_uint32_t)RPMI_ERR_NOTFOUND);
 		resp_dlen = sizeof(*resp);
@@ -688,7 +688,7 @@ rpmi_clock_sg_set_rate(struct rpmi_service_group *group,
 	rpmi_uint32_t clkid = rpmi_to_xe32(trans->is_be,
 				     ((const rpmi_uint32_t *)request_data)[0]);
 
-	if (clkid > clkgrp->clock_count) {
+	if (clkid >= clkgrp->clock_count) {
 		resp[0] = rpmi_to_xe32(trans->is_be,
 				       (rpmi_uint32_t)RPMI_ERR_NOTFOUND);
 		goto done;
@@ -743,7 +743,7 @@ rpmi_clock_sg_get_rate(struct rpmi_service_group *group,
 	rpmi_uint32_t clkid = rpmi_to_xe32(trans->is_be,
 				     ((const rpmi_uint32_t *)request_data)[0]);
 
-	if (clkid > clkgrp->clock_count) {
+	if (clkid >= clkgrp->clock_count) {
 		resp[0] = rpmi_to_xe32(trans->is_be,
 				       (rpmi_uint32_t)RPMI_ERR_NOTFOUND);
 		resp_dlen = sizeof(*resp);


### PR DESCRIPTION
* Fix incorrect bounds checking for clock IDs coming from the AP.
* Fix an incorrect call to `DPRINTF()`.