### PR TITLE
librpmi: syssusp: Complete state changes

### DIFF
--- a/lib/rpmi_context.c
+++ b/lib/rpmi_context.c
@@ -458,7 +458,7 @@ void rpmi_context_process_group_events(struct rpmi_context *cntx,
 	rpmi_env_lock(group->lock);
 	rc = group->process_events(group);
 	rpmi_env_unlock(group->lock);
-	if (rc) {
+	if (rc && rc != RPMI_ERR_BUSY) {
 		DPRINTF("%s: %s: group %s failed with error %d\n",
 			__func__, cntx->name, group->name, rc);
 	}
@@ -487,7 +487,7 @@ void rpmi_context_process_all_events(struct rpmi_context *cntx)
 		rpmi_env_lock(group->lock);
 		rc = group->process_events(group);
 		rpmi_env_unlock(group->lock);
-		if (rc) {
+		if (rc && rc != RPMI_ERR_BUSY) {
 			DPRINTF("%s: %s: group %s failed with error %d\n",
 				__func__, cntx->name, group->name, rc);
 		}

--- a/lib/rpmi_service_group_syssusp.c
+++ b/lib/rpmi_service_group_syssusp.c
@@ -174,7 +174,7 @@ static enum rpmi_error rpmi_syssusp_process_events(struct rpmi_service_group *gr
 	case RPMI_SYSSUSP_STATE_SUSPEND_PENDING:
 		if (!sgsusp->ops->system_suspend_ready(sgsusp->ops_priv,
 						       sgsusp->current_hart_index))
-			return RPMI_SUCCESS;
+			return RPMI_ERR_BUSY;
 		sgsusp->ops->system_suspend_finalize(sgsusp->ops_priv,
 						sgsusp->current_hart_index,
 						sgsusp->current_syssusp_type,
@@ -184,7 +184,7 @@ static enum rpmi_error rpmi_syssusp_process_events(struct rpmi_service_group *gr
 	case RPMI_SYSSUSP_STATE_SUSPENDED:
 		if (!sgsusp->ops->system_suspend_can_resume(sgsusp->ops_priv,
 							    sgsusp->current_hart_index))
-			return RPMI_SUCCESS;
+			return RPMI_ERR_BUSY;
 		status = sgsusp->ops->system_suspend_resume(sgsusp->ops_priv,
 							sgsusp->current_hart_index,
 							sgsusp->current_syssusp_type,


### PR DESCRIPTION
Reverse the logic of the state change checks, because, when they are successful, we want to do the state change, not skip the change with an early return.