### PR TITLE
lib: Return service group version while probing a group

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -717,6 +717,9 @@ struct rpmi_service_group {
 	/** Maximum service ID of the service group */
 	rpmi_uint8_t max_service_id;
 
+	/** Service group version */
+	rpmi_uint32_t servicegroup_version;
+
 	/**
 	 * RISC-V privilagel level bitmap where this group
 	 * is allowed to be accessible. enum rpmi_privilege_level

--- a/lib/rpmi_service_group_clock.c
+++ b/lib/rpmi_service_group_clock.c
@@ -857,6 +857,8 @@ rpmi_service_group_clock_create(rpmi_uint32_t clock_count,
 	group = &clkgrp->group;
 	group->name = "clk";
 	group->servicegroup_id = RPMI_SRVGRP_CLOCK;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
 	/* Allowed for both M-mode and S-mode RPMI context */
 	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK | RPMI_PRIVILEGE_S_MODE_MASK;
 	group->max_service_id = RPMI_CLK_SRV_ID_MAX;

--- a/lib/rpmi_service_group_cppc.c
+++ b/lib/rpmi_service_group_cppc.c
@@ -931,6 +931,8 @@ rpmi_service_group_cppc_create(struct rpmi_hsm *hsm,
 	group = &cppcgrp->group;
 	group->name = "cppc";
 	group->servicegroup_id = RPMI_SRVGRP_CPPC;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
 	/* Allowed for both M-mode and S-mode RPMI context */
 	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK | RPMI_PRIVILEGE_S_MODE_MASK;
 	group->max_service_id = RPMI_CPPC_SRV_ID_MAX;

--- a/lib/rpmi_service_group_hsm.c
+++ b/lib/rpmi_service_group_hsm.c
@@ -332,6 +332,8 @@ struct rpmi_service_group *rpmi_service_group_hsm_create(struct rpmi_hsm *hsm)
 	group = &sghsm->group;
 	group->name = "hsm";
 	group->servicegroup_id = RPMI_SRVGRP_HSM;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
 	/* Allowed only for M-mode RPMI context */
 	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK;
 	group->max_service_id = RPMI_HSM_SRV_ID_MAX;

--- a/lib/rpmi_service_group_sysreset.c
+++ b/lib/rpmi_service_group_sysreset.c
@@ -140,6 +140,8 @@ rpmi_service_group_sysreset_create(rpmi_uint32_t sysreset_type_count,
 	group = &sgrst->group;
 	group->name = "sysreset";
 	group->servicegroup_id = RPMI_SRVGRP_SYSTEM_RESET;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
 	/* Allowed only for M-mode RPMI context */
 	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK;
 	group->max_service_id = RPMI_SYSRST_SRV_ID_MAX;

--- a/lib/rpmi_service_group_syssusp.c
+++ b/lib/rpmi_service_group_syssusp.c
@@ -244,6 +244,8 @@ rpmi_service_group_syssusp_create(struct rpmi_hsm *hsm,
 	group = &sgsusp->group;
 	group->name = "syssusp";
 	group->servicegroup_id = RPMI_SRVGRP_SYSTEM_SUSPEND;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
 	/* Allowed only for M-mode RPMI context */
 	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK;
 	group->max_service_id = RPMI_SYSSUSP_SRV_ID_MAX;


### PR DESCRIPTION
Probing a service group returns the service group version in response message. Add version for each service group currently matching the RPMI spec version and return it in the response if the group is present in an context