### PR TITLE
lib: Add Logging service group

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -198,6 +198,7 @@ enum rpmi_servicegroup_id {
 	RPMI_SRVGRP_MANAGEMENT_MODE	= 0x000B,
 	RPMI_SRVGRP_RAS_AGENT		= 0x000C,
 	RPMI_SRVGRP_REQUEST_FORWARD	= 0x000D,
+	RPMI_SRVGRP_LOGGING			= 0x000E,
 	RPMI_SRVGRP_ID_MAX_COUNT,
 
 	/* Reserved range for service groups */
@@ -367,6 +368,13 @@ enum rpmi_mm_service_id {
 	RPMI_MM_SRV_GET_ATTRIBUTES	= 0x02,
 	RPMI_MM_SRV_COMMUNICATE		= 0x03,
 	RPMI_MM_SRV_ID_MAX
+};
+
+/** RPMI LOGGING ServiceGroup Service IDs */
+enum rpmi_logging_service_id {
+	RPMI_LOGGING_SRV_ENABLE_NOTIFICATION = 0x01,
+	RPMI_LOGGING_SRV_SET_CONFIG = 0x02,
+	RPMI_LOGGING_SRV_ID_MAX,
 };
 
 /** @} */
@@ -2097,6 +2105,38 @@ void rpmi_service_group_mm_destroy(struct rpmi_service_group *group);
 enum rpmi_error rpmi_mm_service_register(struct rpmi_service_group *group,
 					 rpmi_uint32_t num_entries,
 					 struct rpmi_mm_service *iplist);
+
+/**
+ * \defgroup LIBRPMI_LOGGINGSRVGRP_INTERFACE RPMI Logging Service Group Library Interface
+ * @brief Global functions and data structures implemented by the RPMI library
+ * for RPMI Logging service group.
+ * @{
+ */
+
+/** Platform specific logging operations */
+struct rpmi_logging_platform_ops {
+	enum rpmi_error (*do_set_state)(void *priv, rpmi_uint32_t log_type,
+					rpmi_uint32_t datalen_bytes,
+					const void *data);
+};
+
+/**
+ * @brief Create a logging service group instance
+ *
+ * @param[in] ops_priv	pointer to priv data
+ * @return rpmi_service_group	pointer to RPMI service group instance upon
+ * success and NULL upon failure
+ */
+struct rpmi_service_group *
+rpmi_service_group_logging_create(const struct rpmi_logging_platform_ops *ops,
+				  void *ops_priv);
+
+/**
+ * @brief Destroy(free) a logging service group instance
+ *
+ * @param[in] group	pointer to RPMI service group instance
+ */
+void rpmi_service_group_logging_destroy(struct rpmi_service_group *group);
 
 /** @} */
 

--- a/lib/objects.mk
+++ b/lib/objects.mk
@@ -7,6 +7,7 @@
 lib-objs-y += rpmi_context.o
 lib-objs-y += rpmi_hsm.o
 lib-objs-y += rpmi_mm_efi.o
+lib-objs-y += rpmi_service_group_logging.o
 lib-objs-y += rpmi_service_group_hsm.o
 lib-objs-y += rpmi_service_group_mm.o
 lib-objs-y += rpmi_service_group_sysmsi.o

--- a/lib/rpmi_service_group_logging.c
+++ b/lib/rpmi_service_group_logging.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026 Qualcomm Inc.
+ *
+ * Author: Subrahmanya Lingappa <subrahmanya.lingappa@qualcomm.com>
+ */
+
+#include <librpmi.h>
+
+#ifdef DEBUG
+#define DPRINTF(msg...)	rpmi_env_printf(msg)
+#else
+#define DPRINTF(msg...)
+#endif
+
+struct rpmi_logging_group {
+	const struct rpmi_logging_platform_ops *ops;
+	struct rpmi_service_group group;
+	void *ops_priv;
+};
+
+static enum rpmi_error
+rpmi_logging_set_state(struct rpmi_logging_group *sglogging,
+		      rpmi_uint32_t log_type, rpmi_uint32_t datalen_bytes,
+		      const void *data)
+{
+	enum rpmi_error ret;
+
+	ret = sglogging->ops->do_set_state(sglogging->ops_priv, log_type,
+					   datalen_bytes, data);
+
+	return ret;
+}
+
+static enum rpmi_error
+rpmi_logging_sg_set_config(struct rpmi_service_group *group,
+			   struct rpmi_service *service,
+			   struct rpmi_transport *trans,
+			   rpmi_uint16_t request_datalen,
+			   const rpmi_uint8_t *request_data,
+			   rpmi_uint16_t *response_datalen,
+			   rpmi_uint8_t *response_data)
+{
+	enum rpmi_error status;
+	struct rpmi_logging_group *logginggrp = group->priv;
+	rpmi_uint32_t *resp = (void *)response_data;
+	rpmi_uint32_t log_type;
+	const rpmi_uint8_t *data;
+	rpmi_uint32_t datalen_bytes;
+
+	if (request_datalen < sizeof(rpmi_uint32_t)) {
+		resp[0] = rpmi_to_xe32(trans->is_be,
+				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(*resp);
+		return RPMI_SUCCESS;
+	}
+
+	log_type = rpmi_to_xe32(trans->is_be,
+				((const rpmi_uint32_t *)request_data)[0]);
+	data = request_data + sizeof(log_type);
+	datalen_bytes = request_datalen - sizeof(log_type);
+
+	/* change logging config synchronously */
+	status = rpmi_logging_set_state(logginggrp, log_type, datalen_bytes,
+					data);
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)status);
+
+	*response_datalen = sizeof(*resp);
+
+	return RPMI_SUCCESS;
+}
+
+static struct rpmi_service rpmi_logging_services[RPMI_LOGGING_SRV_ID_MAX] = {
+	[RPMI_LOGGING_SRV_SET_CONFIG] = {
+		.service_id = RPMI_LOGGING_SRV_SET_CONFIG,
+		.min_a2p_request_datalen = 16,
+		.process_a2p_request = rpmi_logging_sg_set_config,
+	},
+};
+
+struct rpmi_service_group *rpmi_service_group_logging_create(
+		const struct rpmi_logging_platform_ops *ops,
+		void *ops_priv)
+{
+	struct rpmi_service_group *group;
+	struct rpmi_logging_group *sglogging;
+
+	/* All critical parameters should be non-NULL */
+	if (!ops || !ops->do_set_state) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return NULL;
+	}
+
+	/* Allocate logging group */
+	sglogging = rpmi_env_zalloc(sizeof(*sglogging));
+	if (!sglogging) {
+		DPRINTF("%s: failed to allocate logging service group\n",
+			__func__);
+		return NULL;
+	}
+
+	sglogging->ops = ops;
+	sglogging->ops_priv = ops_priv;
+
+	group = &sglogging->group;
+	group->name = "logging";
+	group->servicegroup_id = RPMI_SRVGRP_LOGGING;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR,
+				  RPMI_SPEC_VERSION_MINOR);
+	/* Allowed only for M-mode RPMI context */
+	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK;
+	group->max_service_id = RPMI_LOGGING_SRV_ID_MAX;
+	group->services = rpmi_logging_services;
+	group->lock = rpmi_env_alloc_lock();
+	group->priv = sglogging;
+
+	return group;
+}
+
+void rpmi_service_group_logging_destroy(struct rpmi_service_group *group)
+{
+	if (!group) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return;
+	}
+
+	rpmi_env_free(group->priv);
+}


### PR DESCRIPTION
This service group defines services used by an application processor to set the log data defined by the UEFI Platform Initialization specification or other similar implementations. This service group provides a reliable way to track the progress of the system for diagnostic purposes. The data provided by the services can then be relayed to other consumers in the system such as the BMC, LCD display, etc.