### PR TITLE
docs: add lightweight project process and release policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to librpmi
+
+This project follows a lightweight Linux/OpenSBI-style workflow.
+
+## Submit changes
+
+1. Fork and create a branch from `main`.
+2. Make one logical change per commit.
+3. Use a subject prefix in commit title:
+   - `lib:`, `include:`, `test:`, `docs:`, `debian:`, `build:`
+4. Add `Signed-off-by:` to every commit (DCO).
+5. Open a pull request against `riscv-software-src/librpmi:main`.
+6. If you add a new service group, include basic tests for it in the same series.
+
+Example:
+
+```
+lib: cpcc: fix frequency bounds check
+
+Fixes: 1a2b3c4d5e6f ("lib: cpcc: add set perf path")
+Signed-off-by: Your Name <you@example.com>
+```
+
+## Required checks before PR
+
+- `make`
+- `make check`
+- `make LIBRPMI_TEST=y`
+
+If documentation changes are included, also run:
+
+- `make docs`
+
+## Commit and trailer rules
+
+- For bug fixes, add `Fixes: <12+ sha> ("subject")` when applicable.
+- For externally reported issues, add `Closes: <public issue URL>`.
+- Keep commit messages self-contained and explain user impact.
+
+Recommended (when applicable): `Reviewed-by:`, `Tested-by:`, `Acked-by:`.
+
+## DCO
+
+By contributing, you certify your work under the Developer Certificate of
+Origin 1.1 by adding `Signed-off-by:` to commits:
+
+`Signed-off-by: Your Name <you@example.com>`

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,47 @@
+# librpmi Maintainers
+
+This file uses a reduced Linux-style format:
+
+- `M:` maintainer
+- `R:` reviewer
+- `S:` status (`Maintained`, `Odd Fixes`, `Orphan`)
+- `F:` file patterns
+
+## LIBRPMI CORE
+
+- `M:` Anup Patel <anup@brainfault.org>
+- `M:` Rahul Pathak <rahul@summations.net>
+- `M:` Ranbir Singh <saini.ranbirs@outlook.com>
+- `M:` Subrahmanya Lingappa <subbukl@gmail.com>
+- `S:` Maintained
+- `F:` `include/`
+- `F:` `lib/`
+- `F:` `Makefile`
+
+## TESTS
+
+- `M:` Anup Patel <anup@brainfault.org>
+- `M:` Rahul Pathak <rahul@summations.net>
+- `M:` Ranbir Singh <saini.ranbirs@outlook.com>
+- `M:` Subrahmanya Lingappa <subbukl@gmail.com>
+- `S:` Maintained
+- `F:` `test/`
+
+## DOCUMENTATION
+
+- `M:` Anup Patel <anup@brainfault.org>
+- `M:` Rahul Pathak <rahul@summations.net>
+- `M:` Ranbir Singh <saini.ranbirs@outlook.com>
+- `M:` Subrahmanya Lingappa <subbukl@gmail.com>
+- `S:` Maintained
+- `F:` `README.md`
+- `F:` `CONTRIBUTING.md`
+- `F:` `RELEASE.md`
+- `F:` `docs/`
+
+## Maintainer policy
+
+- A maintainer should not self-merge their own pull request.
+- At least one reviewer or maintainer approval is required before merge.
+- Maintainers must create signed and annotated release tags (`git tag -s`).
+- New subsystems should add a dedicated section in this file.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ make check
 ```
 Refer: [README in test folder](test/README.md)
 
+## Project process
+
+- [Contributing guide](CONTRIBUTING.md)
+- [Maintainers](MAINTAINERS.md)
+- [Release process](RELEASE.md)
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,40 @@
+# librpmi Release Process
+
+This is the initial lightweight release policy.
+
+## Versioning and tags
+
+- Use SemVer-like tags: `vMAJOR.MINOR.PATCH`
+- Current baseline release: `v1.0.0`
+- Minor feature release example: `v1.1.0`
+- Patch release example: `v1.1.1`
+- Optional pre-release tags: `v1.2.0-rc1`, `v1.2.0-rc2`
+
+Tag rules:
+
+- Maintainers must use signed, annotated tags (`git tag -s`).
+- Never retag an existing version.
+- Tag from the release commit on `main`.
+
+## Cadence
+
+- Planned release cadence: every 6 months.
+- Patch releases: High Impact / Security fixes.
+- Security or build-break regressions can trigger an immediate patch release.
+
+## Simple release checklist
+
+1. Freeze: stop non-critical feature merges.
+2. Validate: run `make`, `make LIBRPMI_TEST=y`, `make check`, and `make docs`.
+3. Create release commit (if needed) and tag `vX.Y.Z`.
+4. Publish release notes with:
+   - Highlights
+   - Breaking/API-visible changes
+   - Bug fixes
+   - Contributor list
+
+## Backport policy
+
+- Bug fixes can be backported to the latest minor line.
+- Prefer minimal-risk backports.
+- Include `Fixes:` tag in backport commits where possible.


### PR DESCRIPTION
Add a minimal starter process modeled after Linux/OpenSBI conventions:\n- add CONTRIBUTING.md with DCO, commit trailers, and required checks\n- add MAINTAINERS.md with Qualcomm maintainers sorted alphabetically\n- add RELEASE.md with cadence and v1.0.0 baseline tag policy\n- link process docs from README.md