### PR TITLE
lib: clock: allow rate change on disabled clocks

### DIFF
--- a/lib/rpmi_service_group_clock.c
+++ b/lib/rpmi_service_group_clock.c
@@ -149,9 +149,6 @@ static enum rpmi_error __rpmi_clock_set_rate(struct rpmi_clock_group *clkgrp,
 	rpmi_uint64_t curr_rate;
 	rpmi_bool_t rate_change_req;
 
-	if (clk->current_state == RPMI_CLK_STATE_DISABLED)
-		return RPMI_ERR_DENIED;
-
 	rate_change_req = clkgrp->ops->rate_change_match(clkgrp->ops_priv,
 							clk->id, rate);
 	if (!rate_change_req)


### PR DESCRIPTION
Changing the rate of a disabled clock is a common thing to do and should be allowed. Otherwise, there is no way to make sure that the clock has the right frequency when it is first enabled.

This makes it possible to use any Linux driver which uses "clk_set_rate()" before "clk_prepare_enable()", for which a random example is [1].

[1]: https://elixir.bootlin.com/linux/v7.0.6/source/drivers/iio/adc/ad4130.c#L1882