### PR TITLE
test: improve RPMI harness and expand BASE coverage

### DIFF
--- a/test/test_common.c
+++ b/test/test_common.c
@@ -78,8 +78,61 @@ static void test_wait(struct rpmi_test_scenario *scene, struct rpmi_test *test,
 	}
 }
 
+static int test_check_no_ack(struct rpmi_test_scenario *scene,
+			     struct rpmi_test *test,
+			     struct rpmi_message *resp_msg)
+{
+	int rc;
+
+	rpmi_env_memset(resp_msg, 0, sizeof(*resp_msg));
+	rc = rpmi_transport_dequeue(scene->xport, RPMI_QUEUE_P2A_ACK, resp_msg);
+	if (rc == RPMI_ERR_IO)
+		return 0;
+
+	if (rc == RPMI_SUCCESS)
+		printf("%s: unexpected acknowledgment for posted request\n", test->name);
+	else
+		printf("%s: failed to check acknowledgment queue (error %d)\n",
+		       test->name, rc);
+
+	return 1;
+}
+
+static int test_verify_header(struct rpmi_test *test, struct rpmi_message *msg,
+			      rpmi_uint16_t token)
+{
+	int failed = 0;
+
+	if (msg->header.flags != RPMI_MSG_ACKNOWLEDGEMENT) {
+		printf("%s: response flags mismatch: expected: %d, got: %d\n",
+		       test->name, RPMI_MSG_ACKNOWLEDGEMENT, msg->header.flags);
+		failed = 1;
+	}
+
+	if (msg->header.servicegroup_id != test->attrs.servicegroup_id) {
+		printf("%s: response servicegroup mismatch: expected: %d, got: %d\n",
+		       test->name, test->attrs.servicegroup_id, msg->header.servicegroup_id);
+		failed = 1;
+	}
+
+	if (msg->header.service_id != test->attrs.service_id) {
+		printf("%s: response service mismatch: expected: %d, got: %d\n",
+		       test->name, test->attrs.service_id, msg->header.service_id);
+		failed = 1;
+	}
+
+	if (msg->header.token != token) {
+		printf("%s: response token mismatch: expected: %d, got: %d\n",
+		       test->name, token, msg->header.token);
+		failed = 1;
+	}
+
+	return failed;
+}
+
 static void test_verify(struct rpmi_test *test, struct rpmi_message *msg,
-			void *exp_data, rpmi_uint16_t exp_data_len)
+			void *exp_data, rpmi_uint16_t exp_data_len,
+			int *nfail)
 {
 	int failed = 0;
 
@@ -106,34 +159,35 @@ static void test_verify(struct rpmi_test *test, struct rpmi_message *msg,
 		}
 	}
 
-	printf("TEST: %-50s \t : %s!\n", test->name, failed ? "Failed" : "Succeeded");
+	if (failed)
+		(*nfail)++;
 }
 
-static void execute_scenario(struct rpmi_test_scenario *scene)
+static int execute_scenario(struct rpmi_test_scenario *scene)
 {
 	struct rpmi_message *req_msg, *resp_msg;
 	rpmi_uint16_t exp_data_len;
 	struct rpmi_test *test;
 	void *exp_data;
-	int i, rc;
+	int i, rc, failed, nfail = 0;
 
 	req_msg = rpmi_env_zalloc(scene->slot_size);
 	if (!req_msg) {
 		printf("Failed to allocate request message\n");
-		return;
+		return 1;
 	}
 	exp_data = rpmi_env_zalloc(RPMI_MSG_DATA_SIZE(scene->slot_size));
 	if (!exp_data) {
 		printf("Failed to allocate expected message\n");
 		rpmi_env_free(req_msg);
-		return;
+		return 1;
 	}
 	resp_msg = rpmi_env_zalloc(scene->slot_size);
 	if (!resp_msg) {
 		printf("Failed to allocate response message\n");
 		rpmi_env_free(exp_data);
 		rpmi_env_free(req_msg);
-		return;
+		return 1;
 	}
 
 	printf("\nExecuting %s test scenario :\n", scene->name);
@@ -148,15 +202,16 @@ static void execute_scenario(struct rpmi_test_scenario *scene)
 			rc = 0;
 		if (rc) {
 			printf("Failed to initialize test %s (error %d)\n", test->name, rc);
+			nfail++;
 			continue;
 		}
 
 		/* Initialize request message header */
 		req_msg->header.servicegroup_id = test->attrs.servicegroup_id;
 		req_msg->header.service_id = test->attrs.service_id;
+		req_msg->header.flags = test->attrs.flags;
 		req_msg->header.datalen = 0;
-		req_msg->header.token = scene->token_sequence;
-		scene->token_sequence++;
+		req_msg->header.token = scene->token_sequence++;
 
 		/* Initialize request message data */
 		if (test->init_request_data)
@@ -178,6 +233,7 @@ static void execute_scenario(struct rpmi_test_scenario *scene)
 			rc = test_run(scene, test, req_msg);
 		if (rc) {
 			printf("Failed to run test %s (error %d)\n", test->name, rc);
+			nfail++;
 			goto skip;
 		}
 
@@ -186,14 +242,31 @@ static void execute_scenario(struct rpmi_test_scenario *scene)
 		else
 			scenario_process(scene);
 
+		failed = 0;
+		if ((test->attrs.flags & RPMI_MSG_FLAGS_TYPE) == RPMI_MSG_POSTED_REQUEST)
+			failed = test_check_no_ack(scene, test, resp_msg);
+
 		/* Wait for test to finish */
 		if (test->wait)
 			test->wait(scene, test, resp_msg);
-		else
+		else if (!failed)
 			test_wait(scene, test, resp_msg);
 
+		if (!failed && (test->attrs.flags &
+				RPMI_MSG_FLAGS_TYPE) == RPMI_MSG_NORMAL_REQUEST)
+			failed = test_verify_header(test, resp_msg, req_msg->header.token);
+
 		/* Verify and report */
-		test_verify(test, resp_msg, exp_data, exp_data_len);
+		if (test->verify)
+			failed += test->verify(scene, test, resp_msg);
+
+		test_verify(test, resp_msg, exp_data, exp_data_len, &failed);
+
+		if (failed)
+			nfail++;
+
+		printf("TEST: %-50s \t : %s!\n", test->name,
+		       failed ? "Failed" : "Succeeded");
 
 skip:
 		/* Cleanup if needed */
@@ -204,6 +277,8 @@ skip:
 	rpmi_env_free(resp_msg);
 	rpmi_env_free(exp_data);
 	rpmi_env_free(req_msg);
+
+	return nfail;
 }
 
 rpmi_uint16_t test_init_request_data_from_attrs(struct rpmi_test_scenario *scene,
@@ -313,13 +388,14 @@ int test_scenario_execute(struct rpmi_test_scenario *scene)
 		return rc;
 	}
 
-	execute_scenario(scene);
+	rc = execute_scenario(scene);
+	if (rc)
+		printf("%d test(s) failed in scenario %s\n", rc, scene->name);
 
-	rc = scene->cleanup(scene);
-	if (rc) {
+	if (scene->cleanup(scene)) {
 		printf("Failed to cleanup test scenario %s\n", scene->name);
-		return rc;
+		return RPMI_ERR_FAILED;
 	}
 
-	return 0;
+	return rc ? RPMI_ERR_FAILED : 0;
 }

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -11,6 +11,10 @@
 #include <librpmi.h>
 #include <stdlib.h>
 
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))
+#endif
+
 /*
  * Qemu shared memory offsets.
  * its better to decode these data from DTS file, hardcoding for now.
@@ -51,6 +55,8 @@ struct rpmi_test {
 		   struct rpmi_message *msg);
 	void (*wait)(struct rpmi_test_scenario *scene, struct rpmi_test *test,
 		    struct rpmi_message *msg);
+	int (*verify)(struct rpmi_test_scenario *scene, struct rpmi_test *test,
+		      struct rpmi_message *msg);
 	void (*cleanup)(struct rpmi_test_scenario *scene, struct rpmi_test *test);
 };
 

--- a/test/test_srvgrp_base.c
+++ b/test/test_srvgrp_base.c
@@ -50,6 +50,27 @@ static rpmi_uint32_t probe_expdata_default[] = {
 	RPMI_BASE_VERSION(1, 0),
 };
 
+static rpmi_uint32_t probe_sysreset_reqdata_default[] = {
+	RPMI_SRVGRP_SYSTEM_RESET,
+};
+
+static rpmi_uint32_t probe_unsupported_expdata_default[] = {
+	RPMI_SUCCESS,
+	0,
+};
+
+static rpmi_uint32_t probe_experimental_reqdata_default[] = {
+	RPMI_SRVGRP_EXPERIMENTAL_START,
+};
+
+static rpmi_uint32_t probe_vendor_reqdata_default[] = {
+	RPMI_SRVGRP_VENDOR_START,
+};
+
+static rpmi_uint32_t invalid_service_expdata_default[] = {
+	RPMI_ERR_NOTSUPP,
+};
+
 static rpmi_uint32_t attribs_expdata_default[] = {
 	RPMI_SUCCESS,
 	RPMI_BASE_FLAGS_F0_PRIVILEGE,
@@ -70,7 +91,7 @@ static struct rpmi_test_scenario scenario_base_default = {
 	.init = test_scenario_default_init,
 	.cleanup = test_scenario_default_cleanup,
 
-	.num_tests = 7,
+	.num_tests = 11,
 	.tests = {
 		{
 			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION",
@@ -139,6 +160,59 @@ static struct rpmi_test_scenario scenario_base_default = {
 				.expected_data_len = sizeof(probe_expdata_default),
 			},
 			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_PROBE_SERVICE_GROUP unsupported",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_PROBE_SERVICE_GROUP,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_sysreset_reqdata_default,
+				.request_data_len = sizeof(probe_sysreset_reqdata_default),
+				.expected_data = probe_unsupported_expdata_default,
+				.expected_data_len = sizeof(probe_unsupported_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_PROBE_SERVICE_GROUP experimental",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_PROBE_SERVICE_GROUP,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_experimental_reqdata_default,
+				.request_data_len = sizeof(probe_experimental_reqdata_default),
+				.expected_data = probe_unsupported_expdata_default,
+				.expected_data_len = sizeof(probe_unsupported_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_PROBE_SERVICE_GROUP vendor",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_PROBE_SERVICE_GROUP,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_vendor_reqdata_default,
+				.request_data_len = sizeof(probe_vendor_reqdata_default),
+				.expected_data = probe_unsupported_expdata_default,
+				.expected_data_len = sizeof(probe_unsupported_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE invalid service",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ID_MAX,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = invalid_service_expdata_default,
+				.expected_data_len = sizeof(invalid_service_expdata_default),
+			},
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
 		{


### PR DESCRIPTION
This PR keeps the original PR #86 history while narrowing it to the RPMI test harness and BASE service-group coverage changes.

Stack
- PR-1: https://github.com/riscv-software-src/librpmi/pull/86  ← this PR
- PR-2: https://github.com/riscv-software-src/librpmi/pull/92
- PR-3: https://github.com/riscv-software-src/librpmi/pull/93
- PR-4: https://github.com/riscv-software-src/librpmi/pull/94
- PR-5: https://github.com/riscv-software-src/librpmi/pull/95
- PR-6: https://github.com/riscv-software-src/librpmi/pull/96
- PR-7: https://github.com/riscv-software-src/librpmi/pull/97
- PR-8: https://github.com/riscv-software-src/librpmi/pull/98
- PR-9: https://github.com/riscv-software-src/librpmi/pull/99
- PR-10: https://github.com/riscv-software-src/librpmi/pull/100
- PR-11: https://github.com/riscv-software-src/librpmi/pull/101

Changes
- Update the shared RPMI test harness so failed comparisons cause test ELF failure and make check failure.
- Extend existing BASE coverage for:
  - ACK header validation
  - Unsupported service-group probes
  - Experimental/vendor service-group probe cases
  - Invalid BASE service ID handling

Validation
- `make LIBRPMI_TEST=y CROSS_COMPILE= && make check CROSS_COMPILE=`
