### PR TITLE
test: add SYSTEM_MSI service group coverage

### DIFF
--- a/test/objects.mk
+++ b/test/objects.mk
@@ -18,3 +18,8 @@ test-elfs-y += test_srvgrp_hsm
 
 test_srvgrp_hsm-objs-y += test/test_log.o
 test_srvgrp_hsm-objs-y += test/test_common.o
+
+test-elfs-y += test_srvgrp_sysmsi
+
+test_srvgrp_sysmsi-objs-y += test/test_log.o
+test_srvgrp_sysmsi-objs-y += test/test_common.o

--- a/test/test_srvgrp_hsm.c
+++ b/test/test_srvgrp_hsm.c
@@ -96,6 +96,33 @@ static rpmi_uint32_t get_hart_state_invalid_hartid_expdata[] = {
 	TEST_HART_STATE_IGNORED_VALUE
 };
 
+/* Get Suspend Types - Request Data */
+static rpmi_uint32_t get_suspend_types_reqdata[] = {
+	0,
+};
+
+/* Get Suspend Types - Response Data */
+static rpmi_uint32_t get_suspend_types_expdata[] = {
+	RPMI_SUCCESS,
+	0,
+	0,
+};
+
+/* Get Suspend Info invalid type - Request Data */
+static rpmi_uint32_t get_suspend_info_invalid_reqdata[] = {
+	0,
+};
+
+/* Get Suspend Info invalid type - Response Data */
+static rpmi_uint32_t get_suspend_info_invalid_expdata[] = {
+	RPMI_ERR_INVALID_PARAM,
+	0,
+	0,
+	0,
+	0,
+	0,
+};
+
 /* Hart Start (valid hartid) - Request Data */
 static rpmi_uint32_t hart_start_valid_hartid_reqdata[] = {
 	TEST_HART_ID_VALID,
@@ -148,6 +175,19 @@ static rpmi_uint32_t hart_suspend_notsupp_reqdata[] = {
 /* Harts Suspend (not supported) - Response Data */
 static rpmi_uint32_t hart_suspend_notsupp_expdata[] = {
 	RPMI_ERR_NOTSUPP,
+};
+
+/* Hart Suspend invalid type - Request Data */
+static rpmi_uint32_t hart_suspend_invalid_type_reqdata[] = {
+	TEST_HART_ID_VALID,
+	0,
+	0,
+	0,
+};
+
+/* Hart Suspend invalid type - Response Data */
+static rpmi_uint32_t hart_suspend_invalid_type_expdata[] = {
+	RPMI_ERR_INVALID_PARAM,
 };
 
 /**
@@ -253,7 +293,7 @@ static struct rpmi_test_scenario scenario_hsm_default = {
 	.init = test_hsm_scenario_init,
 	.cleanup = test_scenario_default_cleanup,
 
-	.num_tests = 10,
+	.num_tests = 13,
 	.tests = {
 		{
 			.name = "ENABLE NOTIFICATION TEST (notifications not supported)",
@@ -326,6 +366,34 @@ static struct rpmi_test_scenario scenario_hsm_default = {
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
 		{
+			.name = "GET SUSPEND TYPES (none configured)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_HSM,
+				.service_id = RPMI_HSM_SRV_GET_SUSPEND_TYPES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_suspend_types_reqdata,
+				.request_data_len = sizeof(get_suspend_types_reqdata),
+				.expected_data = get_suspend_types_expdata,
+				.expected_data_len = sizeof(get_suspend_types_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET SUSPEND INFO (invalid type)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_HSM,
+				.service_id = RPMI_HSM_SRV_GET_SUSPEND_INFO,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_suspend_info_invalid_reqdata,
+				.request_data_len = sizeof(get_suspend_info_invalid_reqdata),
+				.expected_data = get_suspend_info_invalid_expdata,
+				.expected_data_len = sizeof(get_suspend_info_invalid_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
 			.name = "HART START (valid hart id, hart already started)",
 			.attrs = {
 				.servicegroup_id = RPMI_SRVGRP_HSM,
@@ -377,6 +445,20 @@ static struct rpmi_test_scenario scenario_hsm_default = {
 				.request_data_len = sizeof(hart_stop_stopped_hart_reqdata),
 				.expected_data = hart_stop_stopped_hart_expdata,
 				.expected_data_len = sizeof(hart_stop_stopped_hart_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "HART Suspend (invalid type)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_HSM,
+				.service_id = RPMI_HSM_SRV_HART_SUSPEND,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = hart_suspend_invalid_type_reqdata,
+				.request_data_len = sizeof(hart_suspend_invalid_type_reqdata),
+				.expected_data = hart_suspend_invalid_type_expdata,
+				.expected_data_len = sizeof(hart_suspend_invalid_type_expdata),
 			},
 			.init_request_data = test_init_request_data_from_attrs,
 			.init_expected_data = test_init_expected_data_from_attrs,

--- a/test/test_srvgrp_sysmsi.c
+++ b/test/test_srvgrp_sysmsi.c
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024 Ventana Micro Systems Inc.
+ */
+
+#include <librpmi.h>
+#include <stdio.h>
+#include "test_common.h"
+#include "test_log.h"
+
+#define TEST_SYSMSI_COUNT	2
+#define TEST_SYSMSI_VALID_INDEX	0
+#define TEST_SYSMSI_INVALID_INDEX	TEST_SYSMSI_COUNT
+#define TEST_SYSMSI_ADDR_LOW	0x12345000
+#define TEST_SYSMSI_ADDR_HIGH	0x0
+#define TEST_SYSMSI_DATA	0x55aa55aa
+#define TEST_SYSMSI_BAD_ADDR_LOW	0xdead0000
+#define TEST_EVENT_ID		0x0
+#define TEST_REQUEST_STATE_ENABLE	0x1
+
+static rpmi_uint32_t enable_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_ENABLE,
+};
+
+static rpmi_uint32_t enable_notif_expdata[] = {
+	RPMI_ERR_NOTSUPP,
+};
+
+static rpmi_uint32_t get_attrs_expdata[] = {
+	RPMI_SUCCESS,
+	TEST_SYSMSI_COUNT,
+	0,
+	0,
+};
+
+static rpmi_uint32_t get_msi_attrs_reqdata[] = {
+	TEST_SYSMSI_VALID_INDEX,
+};
+
+static rpmi_uint32_t get_msi_attrs_expdata[] = {
+	RPMI_SUCCESS,
+	RPMI_SYSMSI_MSI_ATTRIBUTES_FLAG0_PREF_PRIV,
+	0,
+	0,
+	0,
+	0,
+	0,
+};
+
+static rpmi_uint32_t invalid_msi_reqdata[] = {
+	TEST_SYSMSI_INVALID_INDEX,
+};
+
+static rpmi_uint32_t invalid_param_expdata[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t set_msi_state_reqdata[] = {
+	TEST_SYSMSI_VALID_INDEX,
+	RPMI_SYSMSI_MSI_STATE_ENABLE,
+};
+
+static rpmi_uint32_t success_expdata[] = {
+	RPMI_SUCCESS,
+};
+
+static rpmi_uint32_t get_msi_state_reqdata[] = {
+	TEST_SYSMSI_VALID_INDEX,
+};
+
+static rpmi_uint32_t get_msi_state_expdata[] = {
+	RPMI_SUCCESS,
+	RPMI_SYSMSI_MSI_STATE_ENABLE,
+};
+
+static rpmi_uint32_t set_msi_target_reqdata[] = {
+	TEST_SYSMSI_VALID_INDEX,
+	TEST_SYSMSI_ADDR_LOW,
+	TEST_SYSMSI_ADDR_HIGH,
+	TEST_SYSMSI_DATA,
+};
+
+static rpmi_uint32_t get_msi_target_expdata[] = {
+	RPMI_SUCCESS,
+	TEST_SYSMSI_ADDR_LOW,
+	TEST_SYSMSI_ADDR_HIGH,
+	TEST_SYSMSI_DATA,
+};
+
+static rpmi_uint32_t set_msi_bad_target_reqdata[] = {
+	TEST_SYSMSI_VALID_INDEX,
+	TEST_SYSMSI_BAD_ADDR_LOW,
+	0,
+	TEST_SYSMSI_DATA,
+};
+
+static rpmi_uint32_t invalid_addr_expdata[] = {
+	RPMI_ERR_INVALID_ADDR,
+};
+
+static rpmi_bool_t test_validate_msi_addr(void *priv, rpmi_uint64_t msi_addr)
+{
+	return msi_addr == TEST_SYSMSI_ADDR_LOW;
+}
+
+static rpmi_bool_t test_mmode_preferred(void *priv, rpmi_uint32_t msi_index)
+{
+	return msi_index == TEST_SYSMSI_VALID_INDEX;
+}
+
+static struct rpmi_sysmsi_platform_ops test_sysmsi_ops = {
+	.validate_msi_addr = test_validate_msi_addr,
+	.mmode_preferred = test_mmode_preferred,
+};
+
+static int test_sysmsi_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct rpmi_service_group *grp;
+	int ret;
+
+	ret = test_scenario_default_init(scene);
+	if (ret)
+		return RPMI_ERR_FAILED;
+
+	grp = rpmi_service_group_sysmsi_create(TEST_SYSMSI_COUNT,
+						 TEST_SYSMSI_VALID_INDEX,
+						 &test_sysmsi_ops, NULL);
+	if (!grp) {
+		printf("failed to create rpmi sysmsi service group");
+		return RPMI_ERR_FAILED;
+	}
+
+	rpmi_context_add_group(scene->cntx, grp);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_sysmsi_default = {
+	.name = "System MSI Service Group",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = NULL,
+
+	.init = test_sysmsi_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 10,
+	.tests = {
+		{
+			.name = "ENABLE NOTIFICATION TEST (notifications not supported)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata,
+				.request_data_len = sizeof(enable_notif_reqdata),
+				.expected_data = enable_notif_expdata,
+				.expected_data_len = sizeof(enable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ATTRIBUTES",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_GET_ATTRIBUTES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = get_attrs_expdata,
+				.expected_data_len = sizeof(get_attrs_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET MSI ATTRIBUTES",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_GET_MSI_ATTRIBUTES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_msi_attrs_reqdata,
+				.request_data_len = sizeof(get_msi_attrs_reqdata),
+				.expected_data = get_msi_attrs_expdata,
+				.expected_data_len = sizeof(get_msi_attrs_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET MSI ATTRIBUTES (invalid index)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_GET_MSI_ATTRIBUTES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = invalid_msi_reqdata,
+				.request_data_len = sizeof(invalid_msi_reqdata),
+				.expected_data = invalid_param_expdata,
+				.expected_data_len = sizeof(invalid_param_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "SET MSI STATE (enable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_SET_MSI_STATE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = set_msi_state_reqdata,
+				.request_data_len = sizeof(set_msi_state_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET MSI STATE (enabled)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_GET_MSI_STATE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_msi_state_reqdata,
+				.request_data_len = sizeof(get_msi_state_reqdata),
+				.expected_data = get_msi_state_expdata,
+				.expected_data_len = sizeof(get_msi_state_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET MSI STATE (invalid index)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_GET_MSI_STATE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = invalid_msi_reqdata,
+				.request_data_len = sizeof(invalid_msi_reqdata),
+				.expected_data = invalid_param_expdata,
+				.expected_data_len = sizeof(invalid_param_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "SET MSI TARGET",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_SET_MSI_TARGET,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = set_msi_target_reqdata,
+				.request_data_len = sizeof(set_msi_target_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET MSI TARGET",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_GET_MSI_TARGET,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_msi_state_reqdata,
+				.request_data_len = sizeof(get_msi_state_reqdata),
+				.expected_data = get_msi_target_expdata,
+				.expected_data_len = sizeof(get_msi_target_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "SET MSI TARGET (invalid address)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_SYSTEM_MSI,
+				.service_id = RPMI_SYSMSI_SRV_SET_MSI_TARGET,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = set_msi_bad_target_reqdata,
+				.request_data_len = sizeof(set_msi_bad_target_reqdata),
+				.expected_data = invalid_addr_expdata,
+				.expected_data_len = sizeof(invalid_addr_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+	},
+};
+
+int main(int argc, char *argv[])
+{
+	printf("Test System MSI Service Group\n");
+	return test_scenario_execute(&scenario_sysmsi_default);
+}


### PR DESCRIPTION
This PR adds SYSTEM_MSI service-group test coverage.

Stack
- PR-1: https://github.com/riscv-software-src/librpmi/pull/86
- PR-2: https://github.com/riscv-software-src/librpmi/pull/92
- PR-3: https://github.com/riscv-software-src/librpmi/pull/93  ← base
- PR-4: https://github.com/riscv-software-src/librpmi/pull/94  ← this PR
- PR-5: https://github.com/riscv-software-src/librpmi/pull/95
- PR-6: https://github.com/riscv-software-src/librpmi/pull/96
- PR-7: https://github.com/riscv-software-src/librpmi/pull/97
- PR-8: https://github.com/riscv-software-src/librpmi/pull/98
- PR-9: https://github.com/riscv-software-src/librpmi/pull/99
- PR-10: https://github.com/riscv-software-src/librpmi/pull/100
- PR-11: https://github.com/riscv-software-src/librpmi/pull/101

Depends on: PR-3

Changes
- Add SYSTEM_MSI service-group tests for:
  - Notification unsupported behavior
  - Group and MSI attributes
  - MSI state set/get
  - MSI target set/get
  - Invalid MSI index and invalid target address paths

Validation
- `make LIBRPMI_TEST=y CROSS_COMPILE= && make check CROSS_COMPILE=`
