### PR TITLE
lib: encode voltage capability fields correctly

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -1883,9 +1883,22 @@ enum rpmi_voltage_state {
 enum rpmi_voltage_type {
 	RPMI_VOLT_TYPE_INVALID			= -1,
 	RPMI_VOLT_TYPE_DISCRETE			= 0,
-	RPMI_VOLT_TYPE_LINEAR			= 2,
+	RPMI_VOLT_TYPE_LINEAR			= 1,
 	RPMI_VOLT_TYPE_MAX,
 };
+
+#define RPMI_VOLT_CAPABILITY_CONTROL_POS		0U
+#define RPMI_VOLT_CAPABILITY_CONTROL_MASK		0x1U
+#define RPMI_VOLT_CAPABILITY_FORMAT_POS			1U
+#define RPMI_VOLT_CAPABILITY_FORMAT_MASK		0x7U
+
+#define RPMI_VOLT_CAPABILITY_CONTROL(__control)				\
+	(((__control) & RPMI_VOLT_CAPABILITY_CONTROL_MASK) <<		\
+	 RPMI_VOLT_CAPABILITY_CONTROL_POS)
+
+#define RPMI_VOLT_CAPABILITY_FORMAT(__format)				\
+	(((__format) & RPMI_VOLT_CAPABILITY_FORMAT_MASK) <<		\
+	 RPMI_VOLT_CAPABILITY_FORMAT_POS)
 
 /** voltage domain capabilities */
 enum rpmi_voltage_capability {

--- a/lib/rpmi_service_group_voltage.c
+++ b/lib/rpmi_service_group_voltage.c
@@ -70,7 +70,9 @@ static enum rpmi_error __rpmi_volt_get_attributes(struct rpmi_voltage_group *vol
 	}
 
 	attrs->name = volt->vdata->name;
-	attrs->capability = volt->vdata->voltage_type | volt->vdata->control;
+	attrs->capability =
+		RPMI_VOLT_CAPABILITY_FORMAT(volt->vdata->voltage_type) |
+		RPMI_VOLT_CAPABILITY_CONTROL(volt->vdata->control);
 	attrs->num_levels = volt->vdata->num_levels;
 	attrs->trans_latency = volt->vdata->trans_latency;
 	attrs->config = volt->vdata->config;


### PR DESCRIPTION
Fix the Voltage service group capability word encoding.

The RPMI Voltage `FLAGS` field uses bit 0 for voltage control support and bits 3:1 for voltage format. Encode the fields explicitly so linear domains report the expected format value while preserving the control bit.

This PR is split out from PR #97 based on review feedback and is intended to sit below the Voltage test coverage PR in the stack.