### PR TITLE
lib: base: implement ENABLE_NOTIFICATION service

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -239,6 +239,11 @@ enum rpmi_base_service_id {
 #define RPMI_BASE_FLAGS_F0_PRIVILEGE		(1U << 1)
 #define RPMI_BASE_FLAGS_F0_EV_NOTIFY		(1U << 0)
 
+/** RPMI Base ServiceGroup Event IDs */
+enum rpmi_base_event_id {
+	RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR	= 0x01,
+};
+
 /** RPMI System MSI (SYSMSI) ServiceGroup Service IDs */
 enum rpmi_sysmsi_service_id {
 	RPMI_SYSMSI_SRV_ENABLE_NOTIFICATION	= 0x01,
@@ -685,6 +690,18 @@ void rpmi_context_process_group_events(struct rpmi_context *cntx,
  * @param[in] cntx		pointer to the RPMI context
  */
 void rpmi_context_process_all_events(struct rpmi_context *cntx);
+
+/**
+ * @brief Trigger REQUEST_HANDLE_ERROR event on the Base service group
+ *
+ * This function triggers a REQUEST_HANDLE_ERROR notification event
+ * when the platform firmware cannot handle an application processor's
+ * request (e.g., when ACK enqueue fails). Can be called from outside
+ * librpmi.
+ *
+ * @param[in] cntx		pointer to the RPMI context
+ */
+void rpmi_context_base_request_handle_error(struct rpmi_context *cntx);
 
 /**
  * @brief Find a RPMI service group in a RPMI context

--- a/lib/rpmi_context.c
+++ b/lib/rpmi_context.c
@@ -58,6 +58,15 @@ struct rpmi_base_group {
 	/* Platform info string */
 	char *plat_info;
 
+	/* Notification enabled state for REQUEST_HANDLE_ERROR event */
+	rpmi_bool_t notif_enabled;
+
+	/* Pending REQUEST_HANDLE_ERROR notification flag */
+	rpmi_bool_t pending_request_handle_err;
+
+	/* Pre-allocated notification message buffer */
+	struct rpmi_message *notif_msg;
+
 	struct rpmi_service_group group;
 };
 
@@ -163,6 +172,60 @@ static enum rpmi_error rpmi_base_probe_group(struct rpmi_service_group *group,
 	return RPMI_SUCCESS;
 }
 
+static enum rpmi_error rpmi_base_enable_notification(struct rpmi_service_group *group,
+						     struct rpmi_service *service,
+						     struct rpmi_transport *trans,
+						     rpmi_uint16_t request_datalen,
+						     const rpmi_uint8_t *request_data,
+						     rpmi_uint16_t *response_datalen,
+						     rpmi_uint8_t *response_data)
+{
+	const rpmi_uint32_t *req = (const rpmi_uint32_t *)request_data;
+	rpmi_uint32_t *resp = (void *)response_data;
+	struct rpmi_base_group *base = group->priv;
+	rpmi_uint32_t event_id, req_state;
+
+	/* Notifications require a P2A channel to deliver events */
+	if (!trans->is_p2a_channel) {
+		*response_datalen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_ERR_NOTSUPP);
+		return RPMI_SUCCESS;
+	}
+
+	event_id = rpmi_to_xe32(trans->is_be, req[0]);
+	req_state = rpmi_to_xe32(trans->is_be, req[1]);
+
+	/* Only REQUEST_HANDLE_ERROR event is supported */
+	if (event_id != RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR) {
+		*response_datalen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		return RPMI_SUCCESS;
+	}
+
+	switch (req_state) {
+	case 0: /* Disable */
+		base->notif_enabled = false;
+		base->pending_request_handle_err = false;
+		break;
+	case 1: /* Enable */
+		base->notif_enabled = true;
+		break;
+	case 2: /* Query current state */
+		break;
+	default:
+		*response_datalen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		return RPMI_SUCCESS;
+	}
+
+	/* Return current state in response */
+	*response_datalen = 2 * sizeof(*resp);
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
+	resp[1] = rpmi_to_xe32(trans->is_be, base->notif_enabled ? 1U : 0U);
+
+	return RPMI_SUCCESS;
+}
+
 static enum rpmi_error rpmi_base_get_attributes(struct rpmi_service_group *group,
 						struct rpmi_service *service,
 						struct rpmi_transport *trans,
@@ -179,6 +242,10 @@ static enum rpmi_error rpmi_base_get_attributes(struct rpmi_service_group *group
 	flags |= (cntx->privilege_level == RPMI_PRIVILEGE_M_MODE) ?
 					RPMI_BASE_FLAGS_F0_PRIVILEGE : 0;
 
+	/* Set the event notification support flag only if transport has P2A channel */
+	if (trans->is_p2a_channel)
+		flags |= RPMI_BASE_FLAGS_F0_EV_NOTIFY;
+
 	*response_datalen = 5 * sizeof(*resp);
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
 	resp[1] = rpmi_to_xe32(trans->is_be, flags);
@@ -189,11 +256,51 @@ static enum rpmi_error rpmi_base_get_attributes(struct rpmi_service_group *group
 	return RPMI_SUCCESS;
 }
 
+static enum rpmi_error rpmi_base_process_events(struct rpmi_service_group *group)
+{
+	struct rpmi_base_group *base = group->priv;
+	struct rpmi_transport *trans = base->cntx->trans;
+	struct rpmi_message *notif_msg = base->notif_msg;
+	rpmi_uint32_t *data;
+	enum rpmi_error rc;
+
+	/* Check if notification is enabled and there's a pending event */
+	if (!base->notif_enabled || !base->pending_request_handle_err)
+		return RPMI_SUCCESS;
+
+	/* Prepare P2A notification message */
+	notif_msg->header.servicegroup_id = RPMI_SRVGRP_BASE;
+	notif_msg->header.service_id = 0; /* Not used for notifications */
+	notif_msg->header.flags = RPMI_MSG_NOTIFICATION;
+	notif_msg->header.token = 0; /* Not used for notifications */
+	notif_msg->header.datalen = 2 * sizeof(rpmi_uint32_t);
+
+	data = (rpmi_uint32_t *)notif_msg->data;
+	data[0] = rpmi_to_xe32(trans->is_be, RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR);
+	data[1] = rpmi_to_xe32(trans->is_be, 0); /* Event-specific data (reserved) */
+
+	/* Try to enqueue the notification */
+	rc = rpmi_transport_enqueue(trans, RPMI_QUEUE_P2A_REQ, notif_msg);
+	if (rc == RPMI_SUCCESS) {
+		/* Clear the pending flag on successful enqueue */
+		base->pending_request_handle_err = false;
+		return RPMI_SUCCESS;
+	} else if (rc == RPMI_ERR_IO) {
+		/* Queue is full, will retry later */
+		return RPMI_ERR_BUSY;
+	}
+
+	/* Other error occurred */
+	DPRINTF("%s: failed to enqueue notification (error %d)\n",
+		__func__, rc);
+	return rc;
+}
+
 static struct rpmi_service rpmi_base_services[RPMI_BASE_SRV_ID_MAX] = {
 	[RPMI_BASE_SRV_ENABLE_NOTIFICATION] = {
 		.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
 		.min_a2p_request_datalen = 8,
-		.process_a2p_request = NULL,
+		.process_a2p_request = rpmi_base_enable_notification,
 	},
 	[RPMI_BASE_SRV_GET_IMPLEMENTATION_VERSION] = {
 		.service_id = RPMI_BASE_SRV_GET_IMPLEMENTATION_VERSION,
@@ -262,6 +369,15 @@ static struct rpmi_service_group *rpmi_base_group_create(struct rpmi_context *cn
 		rpmi_env_strncpy(base->plat_info, plat_info, plat_info_len);
 	}
 
+	/* Initialize notification state */
+	base->notif_enabled = false;
+	base->pending_request_handle_err = false;
+
+	/* Allocate pre-allocated notification message buffer */
+	base->notif_msg = rpmi_env_zalloc(cntx->trans->slot_size);
+	if (!base->notif_msg)
+		goto fail_free_plat_info;
+
 	group = &base->group;
 	group->name = "base";
 	group->servicegroup_id = RPMI_SRVGRP_BASE;
@@ -272,10 +388,15 @@ static struct rpmi_service_group *rpmi_base_group_create(struct rpmi_context *cn
 		RPMI_PRIVILEGE_M_MODE_MASK | RPMI_PRIVILEGE_S_MODE_MASK;
 	group->max_service_id = RPMI_BASE_SRV_ID_MAX;
 	group->services = rpmi_base_services;
+	group->process_events = rpmi_base_process_events;
 	group->lock = rpmi_env_alloc_lock();
 	group->priv = base;
 
 	return group;
+
+fail_free_plat_info:
+	if (base->plat_info)
+		rpmi_env_free(base->plat_info);
 
 fail_free_base:
 	rpmi_env_free(base);
@@ -286,6 +407,8 @@ static void rpmi_base_group_destroy(struct rpmi_service_group *group)
 {
 	struct rpmi_base_group *base = group->priv;
 
+	if (base->notif_msg)
+		rpmi_env_free(base->notif_msg);
 	if (base->plat_info)
 		rpmi_env_free(base->plat_info);
 	rpmi_env_free_lock(group->lock);
@@ -395,18 +518,12 @@ void rpmi_context_process_a2p_request(struct rpmi_context *cntx)
 		if (!do_acknowledge)
 			continue;
 
-		/**
-		 * Try pushing the message in queue until successful
-		 * or any other error apart from input/output error
-		 * in case of queue full.
-		 */
-		do {
-			rc = rpmi_transport_enqueue(trans, RPMI_QUEUE_P2A_ACK, amsg);
-		} while (rc == RPMI_ERR_IO);
-
+		rc = rpmi_transport_enqueue(trans, RPMI_QUEUE_P2A_ACK, amsg);
 		if (rc) {
 			DPRINTF("%s: %s: group %s p2a acknowledgement failed (error %d)\n",
 				__func__, cntx->name, group->name, rc);
+			/* Trigger REQUEST_HANDLE_ERROR event on ACK failure */
+			rpmi_context_base_request_handle_error(cntx);
 		}
 
 		if ((rmsg->header.flags & RPMI_MSG_FLAGS_DOORBELL) &&
@@ -479,6 +596,28 @@ void rpmi_context_process_all_events(struct rpmi_context *cntx)
 	}
 
 	rpmi_env_unlock(cntx->groups_lock);
+}
+
+void rpmi_context_base_request_handle_error(struct rpmi_context *cntx)
+{
+	struct rpmi_base_group *base;
+
+	if (!cntx || !cntx->base_group) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return;
+	}
+
+	base = (struct rpmi_base_group *)cntx->base_group->priv;
+
+	/* Only latch the error when notifications are enabled; drop it otherwise.
+	 * An error that arrives during a disabled window must not be queued for
+	 * delivery after re-enable, as the AP opted out of notifications at that
+	 * point and would receive a spurious event on re-enable.
+	 */
+	rpmi_env_lock(cntx->base_group->lock);
+	if (base->notif_enabled)
+		base->pending_request_handle_err = true;
+	rpmi_env_unlock(cntx->base_group->lock);
 }
 
 struct rpmi_service_group *rpmi_context_find_group(struct rpmi_context *cntx,

--- a/test/test_srvgrp_base.c
+++ b/test/test_srvgrp_base.c
@@ -13,6 +13,14 @@
 #define PLAT_INFO	"ventana veyron-v2 plat 1.0"
 #define PLAT_INFO_LEN	(sizeof(PLAT_INFO))
 
+/*
+ * Maximum dequeue attempts before declaring a wait failure.  The transport is
+ * purely in-memory and synchronous: if process_all_events / process_a2p_request
+ * has already run, any enqueued message is immediately visible.  A large bound
+ * keeps the tests from hanging while still allowing for future async changes.
+ */
+#define TEST_DEQUEUE_MAX_RETRIES	1000
+
 static struct plat_info {
 	rpmi_uint32_t status;
 	rpmi_uint32_t plat_id_len;
@@ -22,8 +30,401 @@ static struct plat_info {
 	.plat_info = PLAT_INFO,
 };
 
+static rpmi_uint32_t enable_notif_reqdata_default[] = {
+	RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR,
+	1, /* Enable notification */
+};
+
 static rpmi_uint32_t enable_notif_expdata_default[] = {
-	RPMI_ERR_NOTSUPP,
+	RPMI_SUCCESS,
+	1, /* Current state: enabled */
+};
+
+static rpmi_uint32_t disable_notif_reqdata_default[] = {
+	RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR,
+	0, /* Disable notification */
+};
+
+static rpmi_uint32_t disable_notif_expdata_default[] = {
+	RPMI_SUCCESS,
+	0, /* Current state: disabled */
+};
+
+static rpmi_uint32_t query_notif_reqdata_default[] = {
+	RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR,
+	2, /* Query current state */
+};
+
+/* Query runs after disable, so current state is 0 */
+static rpmi_uint32_t query_notif_expdata_default[] = {
+	RPMI_SUCCESS,
+	0,
+};
+
+static rpmi_uint32_t invalid_event_notif_reqdata_default[] = {
+	0xFF, /* Invalid event ID */
+	1,
+};
+
+static rpmi_uint32_t invalid_event_notif_expdata_default[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t invalid_state_notif_reqdata_default[] = {
+	RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR,
+	3, /* Invalid req_state */
+};
+
+static rpmi_uint32_t invalid_state_notif_expdata_default[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t notif_event_expdata_default[] = {
+	RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR,
+	0, /* Reserved event-specific data */
+};
+
+static int test_base_notif_run(struct rpmi_test_scenario *scene,
+			       struct rpmi_test *test,
+			       struct rpmi_message *msg)
+{
+	/* Re-enable notification before triggering (disabled by prior test) */
+	rpmi_context_base_request_handle_error(scene->cntx);
+	rpmi_context_process_all_events(scene->cntx);
+	return 0;
+}
+
+static void test_base_notif_wait(struct rpmi_test_scenario *scene,
+				 struct rpmi_test *test,
+				 struct rpmi_message *msg)
+{
+	int result, retries = 0;
+
+	rpmi_env_memset(msg, 0, scene->slot_size);
+
+	/* Notification arrives on P2A_REQ queue, not P2A_ACK */
+	do {
+		result = rpmi_transport_dequeue(scene->xport,
+						RPMI_QUEUE_P2A_REQ, msg);
+		retries++;
+	} while (result != RPMI_SUCCESS && retries < TEST_DEQUEUE_MAX_RETRIES);
+
+	if (result != RPMI_SUCCESS)
+		printf("%s: timed out waiting for notification on RPMI_QUEUE_P2A_REQ "
+		       "after %d retries\n", test->name, TEST_DEQUEUE_MAX_RETRIES);
+}
+
+static int test_base_notif_verify(struct rpmi_test_scenario *scene,
+				  struct rpmi_test *test,
+				  struct rpmi_message *msg)
+{
+	int failed = 0;
+
+	if (msg->header.flags != RPMI_MSG_NOTIFICATION) {
+		printf("%s: expected NOTIFICATION flags, got 0x%x\n",
+		       test->name, msg->header.flags);
+		failed = 1;
+	}
+
+	if (msg->header.servicegroup_id != RPMI_SRVGRP_BASE) {
+		printf("%s: expected servicegroup_id %d, got %d\n",
+		       test->name, RPMI_SRVGRP_BASE, msg->header.servicegroup_id);
+		failed = 1;
+	}
+
+	return failed;
+}
+
+/*
+ * Callbacks for the "disable clears pending" scenario.
+ *
+ * The scenario processes A2P requests manually inside each run callback so
+ * that process_all_events is never called implicitly between tests.  This lets
+ * us verify that disabling notifications clears pending_request_handle_err:
+ * if the fix is absent, a pending error latched while notifications were
+ * enabled survives the disable and fires spuriously after re-enable.
+ */
+
+static int test_scenario_no_process(struct rpmi_test_scenario *scene)
+{
+	/* No implicit event processing; tests drive it explicitly in run. */
+	return 0;
+}
+
+/* run: enqueue request and process the A2P queue only */
+static int test_base_notif_clear_run_enqueue(struct rpmi_test_scenario *scene,
+					     struct rpmi_test *test,
+					     struct rpmi_message *msg)
+{
+	int rc;
+
+	do {
+		rc = rpmi_transport_enqueue(scene->xport, RPMI_QUEUE_A2P_REQ, msg);
+	} while (rc == RPMI_ERR_IO);
+	if (rc)
+		return rc;
+
+	rpmi_context_process_a2p_request(scene->cntx);
+	return 0;
+}
+
+/*
+ * run: latch pending_request_handle_err while notifications are enabled,
+ * then enqueue the disable request and process it.  The fix clears the
+ * pending flag during disable; without it the flag survives to re-enable.
+ */
+static int test_base_notif_clear_run_latch_and_disable(struct rpmi_test_scenario *scene,
+							struct rpmi_test *test,
+							struct rpmi_message *msg)
+{
+	int rc;
+
+	rpmi_context_base_request_handle_error(scene->cntx);
+
+	do {
+		rc = rpmi_transport_enqueue(scene->xport, RPMI_QUEUE_A2P_REQ, msg);
+	} while (rc == RPMI_ERR_IO);
+	if (rc)
+		return rc;
+
+	rpmi_context_process_a2p_request(scene->cntx);
+	return 0;
+}
+
+/*
+ * run: re-enable notifications, then call process_all_events.  With the fix,
+ * pending was cleared on disable so no notification fires.  Without the fix,
+ * a stale notification is enqueued to P2A_REQ here.
+ */
+static int test_base_notif_clear_run_reenable(struct rpmi_test_scenario *scene,
+					      struct rpmi_test *test,
+					      struct rpmi_message *msg)
+{
+	int rc;
+
+	do {
+		rc = rpmi_transport_enqueue(scene->xport, RPMI_QUEUE_A2P_REQ, msg);
+	} while (rc == RPMI_ERR_IO);
+	if (rc)
+		return rc;
+
+	rpmi_context_process_a2p_request(scene->cntx);
+	rpmi_context_process_all_events(scene->cntx);
+	return 0;
+}
+
+/* wait: dequeue the acknowledgment response from P2A_ACK */
+static void test_base_notif_clear_wait_ack(struct rpmi_test_scenario *scene,
+					    struct rpmi_test *test,
+					    struct rpmi_message *msg)
+{
+	int result, retries = 0;
+
+	rpmi_env_memset(msg, 0, scene->slot_size);
+
+	do {
+		result = rpmi_transport_dequeue(scene->xport, RPMI_QUEUE_P2A_ACK, msg);
+		retries++;
+	} while (result != RPMI_SUCCESS && retries < TEST_DEQUEUE_MAX_RETRIES);
+
+	if (result != RPMI_SUCCESS)
+		printf("%s: timed out waiting for acknowledgment on RPMI_QUEUE_P2A_ACK "
+		       "after %d retries\n", test->name, TEST_DEQUEUE_MAX_RETRIES);
+}
+
+/* verify: P2A_REQ must be empty — no spurious notification should have been sent */
+static int test_base_notif_clear_no_spurious_verify(struct rpmi_test_scenario *scene,
+						     struct rpmi_test *test,
+						     struct rpmi_message *msg)
+{
+	struct rpmi_message *notif_msg;
+	int rc, failed = 0;
+
+	notif_msg = rpmi_env_zalloc(scene->slot_size);
+	if (!notif_msg)
+		return 1;
+
+	rc = rpmi_transport_dequeue(scene->xport, RPMI_QUEUE_P2A_REQ, notif_msg);
+	if (rc == RPMI_SUCCESS) {
+		printf("%s: spurious REQUEST_HANDLE_ERROR notification delivered after disable\n",
+		       test->name);
+		failed = 1;
+	}
+
+	rpmi_env_free(notif_msg);
+	return failed;
+}
+
+/*
+ * run: trigger an error while notifications are disabled, then re-enable and
+ * run process_all_events.  With the fix, the error is dropped at latch time
+ * (notif_enabled=false) so no notification fires on re-enable.
+ */
+static int test_base_notif_drop_run_trigger_and_reenable(struct rpmi_test_scenario *scene,
+							  struct rpmi_test *test,
+							  struct rpmi_message *msg)
+{
+	int rc;
+
+	/* Error occurs while notifications are still disabled */
+	rpmi_context_base_request_handle_error(scene->cntx);
+
+	do {
+		rc = rpmi_transport_enqueue(scene->xport, RPMI_QUEUE_A2P_REQ, msg);
+	} while (rc == RPMI_ERR_IO);
+	if (rc)
+		return rc;
+
+	rpmi_context_process_a2p_request(scene->cntx);
+	rpmi_context_process_all_events(scene->cntx);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_base_notif_drop_while_disabled = {
+	.name = "Base Notification Drop While Disabled",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.base.plat_info_len = PLAT_INFO_LEN,
+	.base.plat_info = PLAT_INFO,
+
+	.init = test_scenario_default_init,
+	.process = test_scenario_no_process,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 3,
+	.tests = {
+		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (enable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
+				.expected_data = enable_notif_expdata_default,
+				.expected_data_len = sizeof(enable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.run = test_base_notif_clear_run_enqueue,
+			.wait = test_base_notif_clear_wait_ack,
+		},
+		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (disable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = disable_notif_reqdata_default,
+				.request_data_len = sizeof(disable_notif_reqdata_default),
+				.expected_data = disable_notif_expdata_default,
+				.expected_data_len = sizeof(disable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.run = test_base_notif_clear_run_enqueue,
+			.wait = test_base_notif_clear_wait_ack,
+		},
+		{
+			/*
+			 * Trigger an error while disabled, then re-enable.  The fix
+			 * drops errors at latch time when notif_enabled=false, so the
+			 * P2A_REQ queue must remain empty after process_all_events.
+			 */
+			.name = "RPMI_BASE no spurious notification for error-while-disabled",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
+				.expected_data = enable_notif_expdata_default,
+				.expected_data_len = sizeof(enable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.run = test_base_notif_drop_run_trigger_and_reenable,
+			.wait = test_base_notif_clear_wait_ack,
+			.verify = test_base_notif_clear_no_spurious_verify,
+		},
+	},
+};
+
+static struct rpmi_test_scenario scenario_base_notif_clear_on_disable = {
+	.name = "Base Notification Clear On Disable",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.base.plat_info_len = PLAT_INFO_LEN,
+	.base.plat_info = PLAT_INFO,
+
+	.init = test_scenario_default_init,
+	.process = test_scenario_no_process,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 3,
+	.tests = {
+		{
+			/* Enable notifications so the error is latched while enabled */
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (enable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
+				.expected_data = enable_notif_expdata_default,
+				.expected_data_len = sizeof(enable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.run = test_base_notif_clear_run_enqueue,
+			.wait = test_base_notif_clear_wait_ack,
+		},
+		{
+			/*
+			 * Latch pending_request_handle_err while notifications are
+			 * enabled, then disable.  The fix must clear the pending flag
+			 * here so re-enable does not trigger a spurious delivery.
+			 */
+			.name = "RPMI_BASE REQUEST_HANDLE_ERROR pending cleared on disable",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = disable_notif_reqdata_default,
+				.request_data_len = sizeof(disable_notif_reqdata_default),
+				.expected_data = disable_notif_expdata_default,
+				.expected_data_len = sizeof(disable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.run = test_base_notif_clear_run_latch_and_disable,
+			.wait = test_base_notif_clear_wait_ack,
+		},
+		{
+			/*
+			 * Re-enable and call process_all_events.  If the pending flag
+			 * was correctly cleared on disable, P2A_REQ stays empty.
+			 */
+			.name = "RPMI_BASE no spurious notification after disable-clears-pending",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
+				.expected_data = enable_notif_expdata_default,
+				.expected_data_len = sizeof(enable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.run = test_base_notif_clear_run_reenable,
+			.wait = test_base_notif_clear_wait_ack,
+			.verify = test_base_notif_clear_no_spurious_verify,
+		},
+	},
 };
 
 static rpmi_uint32_t impl_ver_expdata_default[] = {
@@ -73,7 +474,7 @@ static rpmi_uint32_t invalid_service_expdata_default[] = {
 
 static rpmi_uint32_t attribs_expdata_default[] = {
 	RPMI_SUCCESS,
-	RPMI_BASE_FLAGS_F0_PRIVILEGE,
+	RPMI_BASE_FLAGS_F0_PRIVILEGE | RPMI_BASE_FLAGS_F0_EV_NOTIFY,
 	0,
 	0,
 	0,
@@ -91,7 +492,7 @@ static struct rpmi_test_scenario scenario_base_default = {
 	.init = test_scenario_default_init,
 	.cleanup = test_scenario_default_cleanup,
 
-	.num_tests = 11,
+	.num_tests = 17,
 	.tests = {
 		{
 			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION",
@@ -99,9 +500,12 @@ static struct rpmi_test_scenario scenario_base_default = {
 				.servicegroup_id = RPMI_SRVGRP_BASE,
 				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
 				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
 				.expected_data = enable_notif_expdata_default,
 				.expected_data_len = sizeof(enable_notif_expdata_default),
 			},
+			.init_request_data = test_init_request_data_from_attrs,
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
 		{
@@ -216,6 +620,91 @@ static struct rpmi_test_scenario scenario_base_default = {
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
 		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (disable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = disable_notif_reqdata_default,
+				.request_data_len = sizeof(disable_notif_reqdata_default),
+				.expected_data = disable_notif_expdata_default,
+				.expected_data_len = sizeof(disable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (query state)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = query_notif_reqdata_default,
+				.request_data_len = sizeof(query_notif_reqdata_default),
+				.expected_data = query_notif_expdata_default,
+				.expected_data_len = sizeof(query_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (invalid event ID)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = invalid_event_notif_reqdata_default,
+				.request_data_len = sizeof(invalid_event_notif_reqdata_default),
+				.expected_data = invalid_event_notif_expdata_default,
+				.expected_data_len = sizeof(invalid_event_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (invalid req_state)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = invalid_state_notif_reqdata_default,
+				.request_data_len = sizeof(invalid_state_notif_reqdata_default),
+				.expected_data = invalid_state_notif_expdata_default,
+				.expected_data_len = sizeof(invalid_state_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			/* Re-enable so the notification event test can fire */
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (re-enable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
+				.expected_data = enable_notif_expdata_default,
+				.expected_data_len = sizeof(enable_notif_expdata_default),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE REQUEST_HANDLE_ERROR notification event",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = 0,
+				.flags = RPMI_MSG_NOTIFICATION,
+				.expected_data = notif_event_expdata_default,
+				.expected_data_len = sizeof(notif_event_expdata_default),
+			},
+			.run = test_base_notif_run,
+			.wait = test_base_notif_wait,
+			.verify = test_base_notif_verify,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
 			.name = "RPMI_BASE_SRV_GET_ATTRIBUTES",
 			.attrs = {
 				.servicegroup_id = RPMI_SRVGRP_BASE,
@@ -229,10 +718,137 @@ static struct rpmi_test_scenario scenario_base_default = {
 	},
 };
 
+/*
+ * Test scenario for a transport without a P2A channel (p2a_req_queue_size=0).
+ * GET_ATTRIBUTES must not advertise EV_NOTIFY, and ENABLE_NOTIFICATION must
+ * return RPMI_ERR_NOTSUPP.
+ */
+static int test_scenario_no_p2a_init(struct rpmi_test_scenario *scene)
+{
+	if (!scene || scene->shm || scene->shmem || scene->xport || scene->cntx)
+		return RPMI_ERR_ALREADY;
+
+	scene->shm = rpmi_env_zalloc(scene->shm_size);
+	if (!scene->shm)
+		return RPMI_ERR_FAILED;
+
+	scene->shmem = rpmi_shmem_create("test_shmem_no_p2a",
+					 (unsigned long)scene->shm, scene->shm_size,
+					 &rpmi_shmem_simple_ops, NULL);
+	if (!scene->shmem) {
+		printf("%s: failed to create test rpmi_shmem\n", __func__);
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	/* p2a_req_queue_size=0: A2P-only transport, is_p2a_channel=false */
+	scene->xport = rpmi_transport_shmem_create("test_transport_no_p2a",
+						   scene->slot_size,
+						   scene->shm_size / 2,
+						   0,
+						   scene->shmem);
+	if (!scene->xport) {
+		printf("%s: failed to create test rpmi_transport\n", __func__);
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->cntx = rpmi_context_create("test_context_no_p2a", scene->xport,
+					  scene->max_num_groups,
+					  RPMI_PRIVILEGE_M_MODE,
+					  scene->base.plat_info_len,
+					  scene->base.plat_info);
+	if (!scene->cntx) {
+		printf("%s: failed to create test rpmi_context\n", __func__);
+		rpmi_transport_shmem_destroy(scene->xport);
+		scene->xport = NULL;
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->token_sequence = 0;
+	return 0;
+}
+
+/* GET_ATTRIBUTES: EV_NOTIFY must be absent when there is no P2A channel */
+static rpmi_uint32_t attribs_expdata_no_p2a[] = {
+	RPMI_SUCCESS,
+	RPMI_BASE_FLAGS_F0_PRIVILEGE, /* no EV_NOTIFY */
+	0,
+	0,
+	0,
+};
+
+/* ENABLE_NOTIFICATION must fail with NOTSUPP when there is no P2A channel */
+static rpmi_uint32_t enable_notif_expdata_no_p2a[] = {
+	RPMI_ERR_NOTSUPP,
+};
+
+static struct rpmi_test_scenario scenario_base_no_p2a_channel = {
+	.name = "Base Service Group No P2A Channel",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.base.plat_info_len = PLAT_INFO_LEN,
+	.base.plat_info = PLAT_INFO,
+
+	.init = test_scenario_no_p2a_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 2,
+	.tests = {
+		{
+			.name = "RPMI_BASE_SRV_GET_ATTRIBUTES (no P2A channel)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_GET_ATTRIBUTES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = attribs_expdata_no_p2a,
+				.expected_data_len = sizeof(attribs_expdata_no_p2a),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION (no P2A channel)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_BASE,
+				.service_id = RPMI_BASE_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata_default,
+				.request_data_len = sizeof(enable_notif_reqdata_default),
+				.expected_data = enable_notif_expdata_no_p2a,
+				.expected_data_len = sizeof(enable_notif_expdata_no_p2a),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+	},
+};
+
 int main(int argc, char *argv[])
 {
+	int rc;
+
 	printf("Test Base Service Group\n");
 
-	/* Execute default scenario */
-	return test_scenario_execute(&scenario_base_default);
+	rc = test_scenario_execute(&scenario_base_default);
+	if (rc)
+		return rc;
+
+	rc = test_scenario_execute(&scenario_base_notif_clear_on_disable);
+	if (rc)
+		return rc;
+
+	rc = test_scenario_execute(&scenario_base_notif_drop_while_disabled);
+	if (rc)
+		return rc;
+
+	return test_scenario_execute(&scenario_base_no_p2a_channel);
 }


### PR DESCRIPTION
This PR implements the ENABLE_NOTIFICATION service for the BASE service group as per the RPMI specification.

## Overview

Adds support for event notifications in the BASE service group, allowing the application processor to subscribe to REQUEST_HANDLE_ERROR events. This is useful for detecting when the platform firmware cannot handle an AP request (e.g., when P2A ACK enqueue fails).

## Changes

### Library Implementation (`lib/rpmi_context.c`)
- Implemented `rpmi_base_enable_notification()` handler to enable/disable notifications based on EVENT_ID and REQ_STATE parameters
- Added `rpmi_base_process_events()` callback to send P2A notification messages when events are pending
- Extended `struct rpmi_base_group` with notification state tracking (enabled flag, pending event flag, pre-allocated message buffer)
- Updated `rpmi_base_get_attributes()` to set `RPMI_BASE_FLAGS_F0_EV_NOTIFY` flag
- Modified `rpmi_context_process_a2p_request()` to trigger REQUEST_HANDLE_ERROR when P2A ACK enqueue fails

### Public API (`include/librpmi.h`)
- Added `enum rpmi_base_event_id` with `RPMI_BASE_EVENT_REQUEST_HANDLE_ERROR`
- Added `rpmi_context_base_request_handle_error()` API for platform firmware to trigger notification events

### Tests (`test/test_srvgrp_base.c`)
- Updated ENABLE_NOTIFICATION test to verify successful enablement
- Updated GET_ATTRIBUTES test to expect EV_NOTIFY flag

## Testing

- [x] `make` - builds successfully without warnings
- [x] `make check` - all tests pass
- [x] `make LIBRPMI_TEST=y` - builds with tests successfully

All existing tests continue to pass. New notification functionality is verified through updated base service group tests.

## Compliance

Implements BASE service group ENABLE_NOTIFICATION service as specified in the RISC-V RPMI specification.