### PR TITLE
lib: implement RAS_AGENT service group

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -79,6 +79,10 @@
 /** Data field size in bytes */
 #define RPMI_MSG_DATA_SIZE(__slot_size)		((__slot_size) - RPMI_MSG_HDR_SIZE)
 
+/** Read a uint32 field at index __idx from a service request data buffer */
+#define RPMI_REQ_U32(__trans, __data, __idx)	\
+	rpmi_to_xe32((__trans)->is_be, ((const rpmi_uint32_t *)(__data))[__idx])
+
 /** Minimum slot size in bytes */
 #define RPMI_SLOT_SIZE_MIN			(64)
 
@@ -347,6 +351,21 @@ enum rpmi_perf_service_id {
 	RPMI_PERF_SRV_GET_FAST_CHANNEL_REGION		= 0x09,
 	RPMI_PERF_SRV_GET_FAST_CHANNEL_ATTRIBUTES	= 0x0A,
 	RPMI_PERF_SRV_ID_MAX,
+};
+
+/** RPMI RAS Agent (RAS) ServiceGroup Service IDs */
+enum rpmi_ras_service_id {
+	RPMI_RAS_SRV_ENABLE_NOTIFICATION	= 0x01,
+	RPMI_RAS_SRV_GET_NUM_ERR_SRCS		= 0x02,
+	RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST	= 0x03,
+	RPMI_RAS_SRV_GET_ERR_SRC_DESC		= 0x04,
+	RPMI_RAS_SRV_ID_MAX,
+};
+
+/** RAS Error Source Descriptor Format Types */
+enum rpmi_ras_desc_format {
+	RPMI_RAS_DESC_FORMAT_GHESV2		= 0x0,
+	RPMI_RAS_DESC_FORMAT_IMPL_SPECIFIC	= 0xF,
 };
 
 /** RPMI Voltage (Volt) ServiceGroup Service IDs */
@@ -2121,7 +2140,82 @@ enum rpmi_error rpmi_mm_service_register(struct rpmi_service_group *group,
 
 /** @} */
 
-/****************************************************************************/
+/******************************************************************************/
+
+/**
+ * \defgroup LIBRPMI_RASAGENTSRVGRP_INTERFACE RPMI RAS Agent Service Group Library Interface
+ * @brief Global functions and data structures implemented by the RPMI library
+ * for RPMI RAS Agent service group.
+ * @{
+ */
+
+/** RAS error source descriptor data */
+struct rpmi_ras_err_src_desc {
+	/** Error source ID */
+	rpmi_uint32_t err_src_id;
+	/** Descriptor format (RPMI_RAS_DESC_FORMAT_*) */
+	rpmi_uint32_t desc_format;
+	/** Total descriptor size in bytes */
+	rpmi_uint32_t desc_size;
+	/** Pointer to descriptor data */
+	const rpmi_uint8_t *desc_data;
+};
+
+/** Platform specific RAS Agent operations */
+struct rpmi_ras_platform_ops {
+	/**
+	 * Optional: initialize platform state, called once during create.
+	 * Returns RPMI_SUCCESS on success, error code otherwise.
+	 */
+	enum rpmi_error (*init)(void *priv);
+
+	/**
+	 * Get total number of error sources.
+	 * Returns RPMI_SUCCESS on success, error code otherwise.
+	 */
+	enum rpmi_error (*get_num_error_sources)(void *priv,
+						 rpmi_uint32_t *num_err_srcs);
+
+	/**
+	 * Get up to @count error source IDs starting at @start_index into @ids.
+	 * Caller guarantees start_index + count <= total from get_num_error_sources.
+	 * Returns RPMI_SUCCESS on success, error code otherwise.
+	 */
+	enum rpmi_error (*get_err_src_id_list)(void *priv,
+					       rpmi_uint32_t start_index,
+					       rpmi_uint32_t count,
+					       rpmi_uint32_t *ids);
+
+	/**
+	 * Get error source descriptor for a given error source ID.
+	 * Returns RPMI_SUCCESS on success, error code otherwise.
+	 */
+	enum rpmi_error (*get_err_src_desc)(void *priv,
+					    rpmi_uint32_t err_src_id,
+					    struct rpmi_ras_err_src_desc *desc);
+};
+
+/**
+ * @brief Create a RAS Agent service group instance
+ *
+ * @param[in] ops		pointer to platform specific RAS operations
+ * @param[in] ops_priv		pointer to private data of platform operations
+ * @return pointer to RPMI service group instance upon success and NULL upon failure
+ */
+struct rpmi_service_group *
+rpmi_service_group_ras_create(const struct rpmi_ras_platform_ops *ops,
+			      void *ops_priv);
+
+/**
+ * @brief Destroy (or free) a RAS Agent service group instance
+ *
+ * @param[in] group	pointer to RPMI service group instance
+ */
+void rpmi_service_group_ras_destroy(struct rpmi_service_group *group);
+
+/** @} */
+
+/******************************************************************************/
 
 /**
  * \defgroup LIBRPMI_LOGGINGSRVGRP_INTERFACE RPMI Logging Service Group Library Interface

--- a/lib/objects.mk
+++ b/lib/objects.mk
@@ -18,6 +18,7 @@ lib-objs-y += rpmi_service_group_cppc.o
 lib-objs-y += rpmi_service_group_device_power.o
 lib-objs-y += rpmi_service_group_performance.o
 lib-objs-y += rpmi_service_group_voltage.o
+lib-objs-y += rpmi_service_group_ras.o
 lib-objs-y += rpmi_shmem.o
 lib-objs-y += rpmi_transport.o
 lib-objs-y += rpmi_transport_shmem.o

--- a/lib/rpmi_service_group_ras.c
+++ b/lib/rpmi_service_group_ras.c
@@ -1,0 +1,302 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 SiFive, Inc.
+ */
+
+#include <librpmi.h>
+
+/* Response field accessors (usable as lvalues) */
+#define RPMI_RAS_RESP_STATUS(__r)		((__r)[0])
+#define RPMI_RAS_RESP_FLAGS(__r)		((__r)[1])
+#define RPMI_RAS_RESP_REMAINING(__r)		((__r)[2])
+#define RPMI_RAS_RESP_RETURNED(__r)		((__r)[3])
+#define RPMI_RAS_RESP_DATA_PTR(__r)		(&(__r)[4])
+#define RPMI_RAS_RESP_ERR_SRC_ID(__r, __i)	((__r)[4 + (__i)])
+/* GET_NUM_ERR_SRCS response: status + count (no paginated header) */
+#define RPMI_RAS_RESP_NUM_ERR_SRCS(__r)		((__r)[1])
+
+/* Fill all four fixed fields of a paginated success response in one call */
+#define RPMI_RAS_PREPARE_RESPONSE(__t, __r, __flags, __remaining, __returned)	\
+	do {									\
+		RPMI_RAS_RESP_STATUS(__r)    = rpmi_to_xe32((__t)->is_be, RPMI_SUCCESS);	\
+		RPMI_RAS_RESP_FLAGS(__r)     = rpmi_to_xe32((__t)->is_be, (__flags));	\
+		RPMI_RAS_RESP_REMAINING(__r) = rpmi_to_xe32((__t)->is_be, (__remaining));\
+		RPMI_RAS_RESP_RETURNED(__r)  = rpmi_to_xe32((__t)->is_be, (__returned));	\
+	} while (0)
+
+/* Request field accessors */
+#define RPMI_RAS_REQ_NOTIF_STATE(__t, __d)	RPMI_REQ_U32(__t, __d, 1)
+#define RPMI_RAS_REQ_START_INDEX(__t, __d)	RPMI_REQ_U32(__t, __d, 0)
+#define RPMI_RAS_REQ_ERR_SRC_ID(__t, __d)	RPMI_REQ_U32(__t, __d, 0)
+#define RPMI_RAS_REQ_BYTE_OFFSET(__t, __d)	RPMI_REQ_U32(__t, __d, 1)
+
+/*
+ * Fixed response header: status, flags, remaining, returned (4 x uint32_t).
+ * Max IDs / bytes that fit in the variable payload of a paginated response.
+ */
+#define RPMI_RAS_MAX_ERR_SRCS_PER_RESP(__slot_size)	\
+	((RPMI_MSG_DATA_SIZE(__slot_size) - (4 * sizeof(rpmi_uint32_t))) /	\
+	 sizeof(rpmi_uint32_t))
+#define RPMI_RAS_MAX_DESC_BYTES_PER_RESP(__slot_size)	\
+	(RPMI_MSG_DATA_SIZE(__slot_size) - (4 * sizeof(rpmi_uint32_t)))
+
+#ifdef LIBRPMI_DEBUG
+#define DPRINTF(msg...)		rpmi_env_printf(msg)
+#else
+#define DPRINTF(msg...)
+#endif
+
+struct rpmi_ras_group {
+	const struct rpmi_ras_platform_ops *ops;
+	void *ops_priv;
+
+	struct rpmi_service_group group;
+};
+
+static enum rpmi_error rpmi_ras_enable_notification(struct rpmi_service_group *group,
+						    struct rpmi_service *service,
+						    struct rpmi_transport *trans,
+						    rpmi_uint16_t request_datalen,
+						    const rpmi_uint8_t *request_data,
+						    rpmi_uint16_t *response_datalen,
+						    rpmi_uint8_t *response_data)
+{
+	rpmi_uint32_t *resp = (void *)response_data;
+	rpmi_uint32_t state;
+
+	*response_datalen = sizeof(rpmi_uint32_t);
+
+	state = RPMI_RAS_REQ_NOTIF_STATE(trans, request_data);
+	if (state > 1) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		return RPMI_SUCCESS;
+	}
+
+	RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, RPMI_ERR_NOTSUPP);
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error rpmi_ras_get_num_err_srcs(struct rpmi_service_group *group,
+						 struct rpmi_service *service,
+						 struct rpmi_transport *trans,
+						 rpmi_uint16_t request_datalen,
+						 const rpmi_uint8_t *request_data,
+						 rpmi_uint16_t *response_datalen,
+						 rpmi_uint8_t *response_data)
+{
+	struct rpmi_ras_group *rasgrp = group->priv;
+	rpmi_uint32_t *resp = (void *)response_data;
+	rpmi_uint32_t num_err_srcs;
+	enum rpmi_error ret;
+
+	ret = rasgrp->ops->get_num_error_sources(rasgrp->ops_priv, &num_err_srcs);
+	if (ret != RPMI_SUCCESS) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, ret);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	RPMI_RAS_RESP_STATUS(resp)       = rpmi_to_xe32(trans->is_be, RPMI_SUCCESS);
+	RPMI_RAS_RESP_NUM_ERR_SRCS(resp) = rpmi_to_xe32(trans->is_be, num_err_srcs);
+
+	*response_datalen = 2 * sizeof(rpmi_uint32_t);
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error rpmi_ras_get_err_srcs_id_list(struct rpmi_service_group *group,
+						     struct rpmi_service *service,
+						     struct rpmi_transport *trans,
+						     rpmi_uint16_t request_datalen,
+						     const rpmi_uint8_t *request_data,
+						     rpmi_uint16_t *response_datalen,
+						     rpmi_uint8_t *response_data)
+{
+	struct rpmi_ras_group *rasgrp = group->priv;
+	rpmi_uint32_t start_index, num_err_srcs, remaining, returned;
+	rpmi_uint32_t *resp = (void *)response_data;
+	rpmi_uint16_t max_err_srcs;
+	enum rpmi_error ret;
+
+	start_index = RPMI_RAS_REQ_START_INDEX(trans, request_data);
+
+	ret = rasgrp->ops->get_num_error_sources(rasgrp->ops_priv, &num_err_srcs);
+	if (ret != RPMI_SUCCESS) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, ret);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	if (start_index >= num_err_srcs) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	max_err_srcs = RPMI_RAS_MAX_ERR_SRCS_PER_RESP(trans->slot_size);
+	remaining = num_err_srcs - start_index;
+	returned = (remaining > max_err_srcs) ? max_err_srcs : remaining;
+
+	ret = rasgrp->ops->get_err_src_id_list(rasgrp->ops_priv, start_index,
+					       returned, RPMI_RAS_RESP_DATA_PTR(resp));
+	if (ret != RPMI_SUCCESS) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, ret);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	for (rpmi_uint32_t i = 0; i < returned; i++)
+		RPMI_RAS_RESP_ERR_SRC_ID(resp, i) =
+			rpmi_to_xe32(trans->is_be, RPMI_RAS_RESP_ERR_SRC_ID(resp, i));
+
+	RPMI_RAS_PREPARE_RESPONSE(trans, resp, 0, remaining - returned, returned);
+
+	*response_datalen = (4 + returned) * sizeof(rpmi_uint32_t);
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error rpmi_ras_get_err_src_desc(struct rpmi_service_group *group,
+						 struct rpmi_service *service,
+						 struct rpmi_transport *trans,
+						 rpmi_uint16_t request_datalen,
+						 const rpmi_uint8_t *request_data,
+						 rpmi_uint16_t *response_datalen,
+						 rpmi_uint8_t *response_data)
+{
+	struct rpmi_ras_group *rasgrp = group->priv;
+	struct rpmi_ras_err_src_desc desc;
+	rpmi_uint32_t err_src_id, byte_offset, remaining, returned;
+	rpmi_uint32_t *resp = (void *)response_data;
+	rpmi_uint8_t *desc_data = (rpmi_uint8_t *)RPMI_RAS_RESP_DATA_PTR(resp);
+	rpmi_uint16_t max_desc_bytes;
+	enum rpmi_error ret;
+
+	err_src_id  = RPMI_RAS_REQ_ERR_SRC_ID(trans, request_data);
+	byte_offset = RPMI_RAS_REQ_BYTE_OFFSET(trans, request_data);
+
+	/* Get descriptor from platform; platform validates err_src_id */
+	ret = rasgrp->ops->get_err_src_desc(rasgrp->ops_priv, err_src_id, &desc);
+	if (ret != RPMI_SUCCESS) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, ret);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Validate descriptor format: only GHESv2 and implementation-specific are defined */
+	if (desc.desc_format != RPMI_RAS_DESC_FORMAT_GHESV2 &&
+	    desc.desc_format != RPMI_RAS_DESC_FORMAT_IMPL_SPECIFIC) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Reject non-zero descriptor size with NULL data pointer */
+	if (desc.desc_size && !desc.desc_data) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	if (byte_offset >= desc.desc_size) {
+		RPMI_RAS_RESP_STATUS(resp) = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	max_desc_bytes = RPMI_RAS_MAX_DESC_BYTES_PER_RESP(trans->slot_size);
+	remaining = desc.desc_size - byte_offset;
+	returned = (remaining > max_desc_bytes) ? max_desc_bytes : remaining;
+
+	/* FLAGS[3:0] = descriptor format */
+	RPMI_RAS_PREPARE_RESPONSE(trans, resp, desc.desc_format,
+				  remaining - returned, returned);
+
+	/* Copy descriptor data */
+	rpmi_env_memcpy(desc_data, desc.desc_data + byte_offset, returned);
+
+	*response_datalen = (4 * sizeof(rpmi_uint32_t)) + returned;
+	return RPMI_SUCCESS;
+}
+
+static struct rpmi_service rpmi_ras_services[RPMI_RAS_SRV_ID_MAX] = {
+	[RPMI_RAS_SRV_ENABLE_NOTIFICATION] = {
+		.service_id = RPMI_RAS_SRV_ENABLE_NOTIFICATION,
+		.min_a2p_request_datalen = 8,
+		.process_a2p_request = rpmi_ras_enable_notification,
+	},
+	[RPMI_RAS_SRV_GET_NUM_ERR_SRCS] = {
+		.service_id = RPMI_RAS_SRV_GET_NUM_ERR_SRCS,
+		.min_a2p_request_datalen = 0,
+		.process_a2p_request = rpmi_ras_get_num_err_srcs,
+	},
+	[RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST] = {
+		.service_id = RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST,
+		.min_a2p_request_datalen = 4,
+		.process_a2p_request = rpmi_ras_get_err_srcs_id_list,
+	},
+	[RPMI_RAS_SRV_GET_ERR_SRC_DESC] = {
+		.service_id = RPMI_RAS_SRV_GET_ERR_SRC_DESC,
+		.min_a2p_request_datalen = 8,
+		.process_a2p_request = rpmi_ras_get_err_src_desc,
+	},
+};
+
+struct rpmi_service_group *
+rpmi_service_group_ras_create(const struct rpmi_ras_platform_ops *ops,
+			      void *ops_priv)
+{
+	struct rpmi_ras_group *rasgrp;
+	struct rpmi_service_group *group;
+	enum rpmi_error ret;
+
+	if (!ops || !ops->get_num_error_sources ||
+	    !ops->get_err_src_id_list || !ops->get_err_src_desc) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return NULL;
+	}
+
+	/* Allocate RAS agent group */
+	rasgrp = rpmi_env_zalloc(sizeof(*rasgrp));
+	if (!rasgrp) {
+		DPRINTF("%s: failed to allocate RAS agent service group instance\n",
+			__func__);
+		return NULL;
+	}
+
+	rasgrp->ops = ops;
+	rasgrp->ops_priv = ops_priv;
+
+	if (ops->init) {
+		ret = ops->init(ops_priv);
+		if (ret != RPMI_SUCCESS) {
+			DPRINTF("%s: platform init failed\n", __func__);
+			rpmi_env_free(rasgrp);
+			return NULL;
+		}
+	}
+
+	group = &rasgrp->group;
+	group->name = "ras_agent";
+	group->servicegroup_id = RPMI_SRVGRP_RAS_AGENT;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
+	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK |
+					RPMI_PRIVILEGE_S_MODE_MASK;
+	group->max_service_id = RPMI_RAS_SRV_ID_MAX;
+	group->services = rpmi_ras_services;
+	group->lock = rpmi_env_alloc_lock();
+	group->priv = rasgrp;
+
+	return group;
+}
+
+void rpmi_service_group_ras_destroy(struct rpmi_service_group *group)
+{
+	if (!group) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return;
+	}
+
+	rpmi_env_free_lock(group->lock);
+	rpmi_env_free(group->priv);
+}

--- a/lib/rpmi_transport.c
+++ b/lib/rpmi_transport.c
@@ -99,8 +99,8 @@ enum rpmi_error rpmi_transport_enqueue(struct rpmi_transport *trans,
 
 	/* Convert header fields to match transport endianness */
 	mhdr = &msg->header;
-	mhdr->servicegroup_id = rpmi_to_xe32(trans->is_be, mhdr->servicegroup_id);
-	mhdr->datalen = rpmi_to_xe32(trans->is_be, mhdr->datalen);
+	mhdr->servicegroup_id = rpmi_to_xe16(trans->is_be, mhdr->servicegroup_id);
+	mhdr->datalen = rpmi_to_xe16(trans->is_be, mhdr->datalen);
 	mhdr->token = rpmi_to_xe16(trans->is_be, mhdr->token);
 
 	/* Enqueue the message */
@@ -114,7 +114,7 @@ enum rpmi_error rpmi_transport_enqueue(struct rpmi_transport *trans,
 	rpmi_env_unlock(trans->lock);
 
 	/* Reverse the endian conversion of header fields */
-	mhdr->servicegroup_id = rpmi_to_xe32(trans->is_be, mhdr->servicegroup_id);
+	mhdr->servicegroup_id = rpmi_to_xe16(trans->is_be, mhdr->servicegroup_id);
 	mhdr->datalen = rpmi_to_xe16(trans->is_be, mhdr->datalen);
 	mhdr->token = rpmi_to_xe16(trans->is_be, mhdr->token);
 
@@ -164,7 +164,7 @@ enum rpmi_error rpmi_transport_dequeue(struct rpmi_transport *trans,
 	/* Convert header fields to native endianness */
 	if (!rc) {
 		mhdr = &out_msg->header;
-		mhdr->servicegroup_id = rpmi_to_xe32(trans->is_be, mhdr->servicegroup_id);
+		mhdr->servicegroup_id = rpmi_to_xe16(trans->is_be, mhdr->servicegroup_id);
 		mhdr->datalen = rpmi_to_xe16(trans->is_be, mhdr->datalen);
 		mhdr->token = rpmi_to_xe16(trans->is_be, mhdr->token);
 	}

--- a/test/objects.mk
+++ b/test/objects.mk
@@ -63,3 +63,8 @@ test-elfs-y += test_srvgrp_logging
 
 test_srvgrp_logging-objs-y += test/test_log.o
 test_srvgrp_logging-objs-y += test/test_common.o
+
+test-elfs-y += test_srvgrp_ras
+
+test_srvgrp_ras-objs-y += test/test_log.o
+test_srvgrp_ras-objs-y += test/test_common.o

--- a/test/test_srvgrp_ras.c
+++ b/test/test_srvgrp_ras.c
@@ -1,0 +1,537 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 SiFive, Inc.
+ */
+
+#include <librpmi.h>
+#include <stdio.h>
+#include "test_common.h"
+#include "test_log.h"
+
+#define TEST_EVENT_ID			0x0
+#define TEST_REQUEST_STATE_ENABLE	0x1
+
+/* Test error source IDs */
+#define TEST_RAS_ERR_SRC_ID_0		0x100
+#define TEST_RAS_ERR_SRC_ID_1		0x101
+#define TEST_RAS_ERR_SRC_ID_2		0x102
+#define TEST_RAS_ERR_SRC_INVALID	0x999
+
+static const rpmi_uint32_t test_ras_err_src_ids[] = {
+	TEST_RAS_ERR_SRC_ID_0,
+	TEST_RAS_ERR_SRC_ID_1,
+	TEST_RAS_ERR_SRC_ID_2,
+};
+
+/* Mock GHESv2 descriptor (simplified for testing) */
+static rpmi_uint8_t test_ghesv2_desc[] = {
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+};
+
+/* Test data for ENABLE_NOTIFICATION */
+static rpmi_uint32_t enable_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_ENABLE
+};
+
+static rpmi_uint32_t enable_notif_expdata[] = {
+	RPMI_ERR_NOTSUPP,
+};
+
+/* Test data for GET_NUM_ERR_SRCS */
+static rpmi_uint32_t get_num_err_srcs_expdata[] = {
+	RPMI_SUCCESS,
+	3, /* number of error sources */
+};
+
+/* Test data for GET_ERR_SRCS_ID_LIST */
+static rpmi_uint32_t get_err_srcs_list_reqdata_start0[] = {
+	0, /* start_index */
+};
+
+static rpmi_uint32_t get_err_srcs_list_expdata_start0[] = {
+	RPMI_SUCCESS,
+	0, /* FLAGS */
+	0, /* REMAINING */
+	3, /* RETURNED */
+	TEST_RAS_ERR_SRC_ID_0,
+	TEST_RAS_ERR_SRC_ID_1,
+	TEST_RAS_ERR_SRC_ID_2,
+};
+
+static rpmi_uint32_t get_err_srcs_list_reqdata_invalid[] = {
+	100, /* invalid start_index */
+};
+
+static rpmi_uint32_t get_err_srcs_list_expdata_invalid[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t get_err_srcs_list_reqdata_start1[] = {
+	1, /* start_index */
+};
+
+static rpmi_uint32_t get_err_srcs_list_expdata_start1[] = {
+	RPMI_SUCCESS,
+	0, /* FLAGS */
+	0, /* REMAINING */
+	2, /* RETURNED */
+	TEST_RAS_ERR_SRC_ID_1,
+	TEST_RAS_ERR_SRC_ID_2,
+};
+
+/* Test data for GET_ERR_SRC_DESC */
+static rpmi_uint32_t get_err_src_desc_reqdata_valid[] = {
+	TEST_RAS_ERR_SRC_ID_0,
+	0, /* byte_offset */
+};
+
+static rpmi_uint32_t get_err_src_desc_reqdata_invalid_id[] = {
+	TEST_RAS_ERR_SRC_INVALID,
+	0, /* byte_offset */
+};
+
+static rpmi_uint32_t get_err_src_desc_expdata_invalid_id[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t get_err_src_desc_reqdata_invalid_offset[] = {
+	TEST_RAS_ERR_SRC_ID_0,
+	1000, /* invalid byte_offset */
+};
+
+static rpmi_uint32_t get_err_src_desc_expdata_invalid_offset[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t get_err_src_desc_reqdata_offset[] = {
+	TEST_RAS_ERR_SRC_ID_0,
+	8, /* byte_offset */
+};
+
+/* test_ghesv2_desc[8..31] packed as LE uint32 words */
+static rpmi_uint32_t get_err_src_desc_expdata_offset[] = {
+	RPMI_SUCCESS,
+	RPMI_RAS_DESC_FORMAT_GHESV2,
+	0,  /* REMAINING = 0 */
+	24, /* RETURNED = 24 bytes */
+	0x0b0a0908, 0x0f0e0d0c,
+	0x13121110, 0x17161514,
+	0x1b1a1918, 0x1f1e1d1c,
+};
+
+/* Expected data for GET_ERR_SRC_DESC with partial descriptor */
+static rpmi_uint32_t get_err_src_desc_expdata_valid[] = {
+	RPMI_SUCCESS,
+	RPMI_RAS_DESC_FORMAT_GHESV2, /* FLAGS[3:0] = format */
+	0, /* REMAINING = 0 (all data returned) */
+	32, /* RETURNED = 32 bytes */
+	/* First 32 bytes of test_ghesv2_desc */
+	0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,
+	0x13121110, 0x17161514, 0x1b1a1918, 0x1f1e1d1c,
+};
+
+static enum rpmi_error test_ras_get_num_error_sources(void *priv,
+						      rpmi_uint32_t *num_err_srcs)
+{
+	*num_err_srcs = sizeof(test_ras_err_src_ids) / sizeof(rpmi_uint32_t);
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error test_ras_get_err_src_id_list(void *priv,
+						    rpmi_uint32_t start_index,
+						    rpmi_uint32_t count,
+						    rpmi_uint32_t *ids)
+{
+	rpmi_uint32_t i;
+
+	for (i = 0; i < count; i++)
+		ids[i] = test_ras_err_src_ids[start_index + i];
+
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error test_ras_get_err_src_desc(void *priv,
+						 rpmi_uint32_t err_src_id,
+						 struct rpmi_ras_err_src_desc *desc)
+{
+	if (!desc)
+		return RPMI_ERR_INVALID_PARAM;
+
+	/* Only support the test error source IDs */
+	if (err_src_id != TEST_RAS_ERR_SRC_ID_0 &&
+	    err_src_id != TEST_RAS_ERR_SRC_ID_1 &&
+	    err_src_id != TEST_RAS_ERR_SRC_ID_2)
+		return RPMI_ERR_INVALID_PARAM;
+
+	desc->err_src_id = err_src_id;
+	desc->desc_format = RPMI_RAS_DESC_FORMAT_GHESV2;
+	desc->desc_size = sizeof(test_ghesv2_desc);
+	desc->desc_data = test_ghesv2_desc;
+
+	printf("get_err_src_desc: ID 0x%x fmt=%d size=%d bytes\n",
+	       err_src_id, desc->desc_format, desc->desc_size);
+
+	return RPMI_SUCCESS;
+}
+
+static struct rpmi_ras_platform_ops test_ras_ops = {
+	.get_num_error_sources = test_ras_get_num_error_sources,
+	.get_err_src_id_list = test_ras_get_err_src_id_list,
+	.get_err_src_desc = test_ras_get_err_src_desc,
+};
+
+static int test_ras_scenario_init(struct rpmi_test_scenario *scene)
+{
+	int ret;
+	struct rpmi_service_group *grp;
+
+	ret = test_scenario_default_init(scene);
+	if (ret)
+		return RPMI_ERR_FAILED;
+
+	grp = rpmi_service_group_ras_create(&test_ras_ops, NULL);
+	if (!grp) {
+		printf("failed to create RAS agent service group\n");
+		return RPMI_ERR_FAILED;
+	}
+
+	rpmi_context_add_group(scene->cntx, grp);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_ras_default = {
+	.name = "RAS Agent Service Group",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = NULL,
+
+	.init = test_ras_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 9,
+	.tests = {
+		{
+			.name = "ENABLE NOTIFICATION TEST (notifications not supported)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata,
+				.request_data_len = sizeof(enable_notif_reqdata),
+				.expected_data = enable_notif_expdata,
+				.expected_data_len = sizeof(enable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET NUM ERR SRCS TEST",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_NUM_ERR_SRCS,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = get_num_err_srcs_expdata,
+				.expected_data_len = sizeof(get_num_err_srcs_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRCS ID LIST TEST (start_index=0)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_srcs_list_reqdata_start0,
+				.request_data_len = sizeof(get_err_srcs_list_reqdata_start0),
+				.expected_data = get_err_srcs_list_expdata_start0,
+				.expected_data_len = sizeof(get_err_srcs_list_expdata_start0),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRCS ID LIST TEST (start_index=1)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_srcs_list_reqdata_start1,
+				.request_data_len = sizeof(get_err_srcs_list_reqdata_start1),
+				.expected_data = get_err_srcs_list_expdata_start1,
+				.expected_data_len = sizeof(get_err_srcs_list_expdata_start1),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRCS ID LIST TEST (invalid start_index)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_srcs_list_reqdata_invalid,
+				.request_data_len = sizeof(get_err_srcs_list_reqdata_invalid),
+				.expected_data = get_err_srcs_list_expdata_invalid,
+				.expected_data_len = sizeof(get_err_srcs_list_expdata_invalid),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRC DESC TEST (valid error source)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRC_DESC,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_src_desc_reqdata_valid,
+				.request_data_len = sizeof(get_err_src_desc_reqdata_valid),
+				.expected_data = get_err_src_desc_expdata_valid,
+				.expected_data_len = sizeof(get_err_src_desc_expdata_valid),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRC DESC TEST (invalid error source ID)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRC_DESC,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_src_desc_reqdata_invalid_id,
+				.request_data_len = sizeof(get_err_src_desc_reqdata_invalid_id),
+				.expected_data = get_err_src_desc_expdata_invalid_id,
+				.expected_data_len = sizeof(get_err_src_desc_expdata_invalid_id),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRC DESC TEST (non-zero byte offset)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRC_DESC,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_src_desc_reqdata_offset,
+				.request_data_len = sizeof(get_err_src_desc_reqdata_offset),
+				.expected_data = get_err_src_desc_expdata_offset,
+				.expected_data_len = sizeof(get_err_src_desc_expdata_offset),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ERR SRC DESC TEST (invalid byte offset)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRC_DESC,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_src_desc_reqdata_invalid_offset,
+				.request_data_len = sizeof(get_err_src_desc_reqdata_invalid_offset),
+				.expected_data = get_err_src_desc_expdata_invalid_offset,
+				.expected_data_len =
+					sizeof(get_err_src_desc_expdata_invalid_offset),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+	},
+};
+
+/* S-mode scenario: create context with RPMI_PRIVILEGE_S_MODE */
+static int test_ras_smode_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct rpmi_service_group *grp;
+
+	scene->shm = rpmi_env_zalloc(scene->shm_size);
+	if (!scene->shm)
+		return RPMI_ERR_FAILED;
+
+	scene->shmem = rpmi_shmem_create("test_shmem",
+					 (unsigned long)scene->shm, scene->shm_size,
+					 &rpmi_shmem_simple_ops, NULL);
+	if (!scene->shmem) {
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->xport = rpmi_transport_shmem_create("test_transport", scene->slot_size,
+						   ((scene->shm_size * 3) / 4) / 2,
+						   ((scene->shm_size * 1) / 4) / 2,
+						   scene->shmem);
+	if (!scene->xport) {
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->cntx = rpmi_context_create("test_context_smode", scene->xport,
+					  scene->max_num_groups,
+					  RPMI_PRIVILEGE_S_MODE,
+					  scene->base.plat_info_len, scene->base.plat_info);
+	if (!scene->cntx) {
+		rpmi_transport_shmem_destroy(scene->xport);
+		scene->xport = NULL;
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->token_sequence = 0;
+
+	grp = rpmi_service_group_ras_create(&test_ras_ops, NULL);
+	if (!grp) {
+		printf("failed to create RAS agent service group\n");
+		return RPMI_ERR_FAILED;
+	}
+
+	rpmi_context_add_group(scene->cntx, grp);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_ras_smode = {
+	.name = "RAS Agent Service Group (S-mode)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = NULL,
+
+	.init = test_ras_smode_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 4,
+	.tests = {
+		{
+			.name = "S-MODE: ENABLE NOTIFICATION TEST",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata,
+				.request_data_len = sizeof(enable_notif_reqdata),
+				.expected_data = enable_notif_expdata,
+				.expected_data_len = sizeof(enable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "S-MODE: GET NUM ERR SRCS TEST",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_NUM_ERR_SRCS,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = get_num_err_srcs_expdata,
+				.expected_data_len = sizeof(get_num_err_srcs_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "S-MODE: GET ERR SRCS ID LIST TEST (start_index=0)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_srcs_list_reqdata_start0,
+				.request_data_len = sizeof(get_err_srcs_list_reqdata_start0),
+				.expected_data = get_err_srcs_list_expdata_start0,
+				.expected_data_len = sizeof(get_err_srcs_list_expdata_start0),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "S-MODE: GET ERR SRC DESC TEST (valid error source)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRC_DESC,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_src_desc_reqdata_valid,
+				.request_data_len = sizeof(get_err_src_desc_reqdata_valid),
+				.expected_data = get_err_src_desc_expdata_valid,
+				.expected_data_len = sizeof(get_err_src_desc_expdata_valid),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+	},
+};
+
+/* Big-endian scenario: set is_be on transport, verify IDs are xe32-encoded */
+static int test_ras_be_scenario_init(struct rpmi_test_scenario *scene)
+{
+	int ret;
+
+	ret = test_ras_scenario_init(scene);
+	if (ret)
+		return ret;
+
+	scene->xport->is_be = true;
+	return 0;
+}
+
+static rpmi_uint16_t test_be_id_list_init_expected_data(
+	struct rpmi_test_scenario *scene,
+	struct rpmi_test *test,
+	void *data, rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *d = (rpmi_uint32_t *)data;
+
+	d[0] = rpmi_to_xe32(true, RPMI_SUCCESS);
+	d[1] = rpmi_to_xe32(true, 0);                    /* FLAGS */
+	d[2] = rpmi_to_xe32(true, 0);                    /* REMAINING */
+	d[3] = rpmi_to_xe32(true, 3);                    /* RETURNED */
+	d[4] = rpmi_to_xe32(true, TEST_RAS_ERR_SRC_ID_0);
+	d[5] = rpmi_to_xe32(true, TEST_RAS_ERR_SRC_ID_1);
+	d[6] = rpmi_to_xe32(true, TEST_RAS_ERR_SRC_ID_2);
+
+	return 7 * sizeof(rpmi_uint32_t);
+}
+
+static struct rpmi_test_scenario scenario_ras_be = {
+	.name = "RAS Agent Service Group (big-endian)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = NULL,
+
+	.init = test_ras_be_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 1,
+	.tests = {
+		{
+			.name = "BE: GET ERR SRCS ID LIST (start_index=0, IDs byte-swapped)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_RAS_AGENT,
+				.service_id = RPMI_RAS_SRV_GET_ERR_SRCS_ID_LIST,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_err_srcs_list_reqdata_start0,
+				.request_data_len = sizeof(get_err_srcs_list_reqdata_start0),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_be_id_list_init_expected_data,
+		},
+	},
+};
+
+int main(int argc, char *argv[])
+{
+	int rc = 0;
+
+	printf("Test RAS Agent Service Group\n");
+	rc |= test_scenario_execute(&scenario_ras_default);
+	rc |= test_scenario_execute(&scenario_ras_smode);
+	rc |= test_scenario_execute(&scenario_ras_be);
+	return rc;
+}


### PR DESCRIPTION
This PR implements the **RAS_AGENT** service group as specified in RPMI specification Section 4.12, providing services to enumerate error sources and retrieve their descriptors.

## Overview

The RAS_AGENT service group enables platform firmware to expose error sources to the application processor, allowing enumeration of error sources and retrieval of their descriptors in various formats (GHESv2/ACPI or implementation-specific).

## Changes

### 1. Library Implementation (`lib/rpmi_service_group_ras.c`)

Implements all 4 services defined in the RPMI specification:

#### Services
- **RAS_ENABLE_NOTIFICATION** (0x01)
  - Returns `RPMI_ERR_NOTSUPP` (no events defined per specification)
  - Validates event ID and request state parameters

- **RAS_GET_NUM_ERR_SRCS** (0x02)
  - Returns total number of error sources in the system
  - No request parameters required

- **RAS_GET_ERR_SRCS_ID_LIST** (0x03)
  - Returns list of error source IDs with pagination support
  - Handles `START_INDEX` for partial list retrieval
  - Returns `REMAINING` and `RETURNED` counts
  - Validates start index bounds

- **RAS_GET_ERR_SRC_DESC** (0x04)
  - Returns error source descriptors with pagination support
  - Handles `BYTE_OFFSET` for partial descriptor retrieval
  - Supports GHESv2 (ACPI/APEI) format (`0x0`)
  - Supports implementation-specific format (`0xF`)
  - Validates error source ID and byte offset

#### Features
- **Pagination Support**: Automatically handles large data that exceeds transport slot size
- **Descriptor Format Support**: FLAGS[3:0] indicates format (GHESv2 or implementation-specific)
- **Platform HAL Interface**: Simple callback interface for platform descriptor retrieval
- **Endianness Handling**: Proper `rpmi_to_xe32()` usage for transport compatibility
- **Memory Safety**: Bounds checking, NULL pointer validation, overflow protection
- **Error Handling**: Comprehensive validation with appropriate error codes

### 2. Tests:

test/test_srvgrp_ras.c  - RAS test suite (new, 310 lines)
test/objects.mk  - Test build configuration

 ## Testing

- [x] `make` - builds successfully without warnings
- [x] `make check` - all tests pass
- [x] `make LIBRPMI_TEST=y` - builds with tests successfully

All existing tests continue to pass. New notification functionality is verified through updated base service group tests.

## Compliance

Implements RAS_AGENT Service as specified in the RISC-V RPMI specification.