### PR TITLE
lib: implement REQUEST_FORWARD service group

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -386,6 +386,19 @@ enum rpmi_volt_service_id {
 	RPMI_VOLT_SRV_ID_MAX,
 };
 
+/** RPMI Request Forward (REQFWD) ServiceGroup Service IDs */
+enum rpmi_reqfwd_service_id {
+	RPMI_REQFWD_SRV_ENABLE_NOTIFICATION		= 0x01,
+	RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE	= 0x02,
+	RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE	= 0x03,
+	RPMI_REQFWD_SRV_ID_MAX,
+};
+
+/** RPMI Request Forward Event IDs */
+enum rpmi_reqfwd_event_id {
+	RPMI_REQFWD_EVENT_NEW_MESSAGE	= 0x01,
+};
+
 /** RPMI Management Mode (MM) ServiceGroup Service IDs */
 enum rpmi_mm_service_id {
 	RPMI_MM_SRV_ENABLE_NOTIFICATION	= 0x01,
@@ -2274,6 +2287,73 @@ rpmi_service_group_logging_create(const struct rpmi_logging_platform_ops *ops,
  * @param[in] group	pointer to RPMI service group instance
  */
 void rpmi_service_group_logging_destroy(struct rpmi_service_group *group);
+
+/** @} */
+
+/******************************************************************************/
+
+/**
+ * \defgroup LIBRPMI_REQFWDSRVGRP_INTERFACE RPMI Request Forward Service Group Library Interface
+ * @brief Global functions and data structures implemented by the RPMI library
+ * for RPMI Request Forward service group.
+ * @{
+ */
+
+/** Forwarded RPMI Request Message */
+struct rpmi_reqfwd_message {
+	rpmi_uint32_t	msg_size;
+	const rpmi_uint8_t *msg_data;
+};
+
+/** Platform specific Request Forward operations */
+struct rpmi_reqfwd_platform_ops {
+	/**
+	 * Get the current (oldest) forwarded RPMI request message
+	 **/
+	enum rpmi_error (*get_current_message)(void *priv,
+					       struct rpmi_reqfwd_message *msg);
+
+	/**
+	 * Complete the current forwarded RPMI request message
+	 **/
+	enum rpmi_error (*complete_current_message)(void *priv,
+						    rpmi_uint32_t resp_data_len,
+						    const rpmi_uint8_t *resp_data,
+						    rpmi_uint32_t *num_messages);
+};
+
+/**
+ * @brief Create a Request Forward service group instance
+ *
+ * @param[in] ops		pointer to platform specific request forward operations
+ * @param[in] ops_priv		pointer to private data of platform operations
+ * @param[in] trans		pointer to the RPMI transport (required for P2A notifications)
+ * @return rpmi_service_group *	pointer to RPMI service group instance upon
+ * success and NULL upon failure
+ */
+struct rpmi_service_group *
+rpmi_service_group_reqfwd_create(const struct rpmi_reqfwd_platform_ops *ops,
+				 void *ops_priv,
+				 struct rpmi_transport *trans);
+
+/**
+ * @brief Destroy(free) a Request Forward service group instance
+ *
+ * @param[in] group	pointer to RPMI service group instance
+ */
+void rpmi_service_group_reqfwd_destroy(struct rpmi_service_group *group);
+
+/**
+ * @brief Trigger REQFWD_NEW_MESSAGE notification event
+ *
+ * @param[in] group		pointer to RPMI service group instance
+ * @param[in] event_data_len	length of event data (first N bytes of message)
+ * @param[in] event_data	pointer to event data
+ * @return enum rpmi_error	RPMI_SUCCESS on success, error code otherwise
+ */
+enum rpmi_error rpmi_reqfwd_trigger_new_message(struct rpmi_service_group *group,
+						rpmi_uint32_t event_data_len,
+						const rpmi_uint8_t *event_data);
 
 /** @} */
 

--- a/lib/objects.mk
+++ b/lib/objects.mk
@@ -19,6 +19,7 @@ lib-objs-y += rpmi_service_group_device_power.o
 lib-objs-y += rpmi_service_group_performance.o
 lib-objs-y += rpmi_service_group_voltage.o
 lib-objs-y += rpmi_service_group_ras.o
+lib-objs-y += rpmi_service_group_reqfwd.o
 lib-objs-y += rpmi_shmem.o
 lib-objs-y += rpmi_transport.o
 lib-objs-y += rpmi_transport_shmem.o

--- a/lib/rpmi_service_group_reqfwd.c
+++ b/lib/rpmi_service_group_reqfwd.c
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026 SiFive, Inc.
+ */
+
+#include <librpmi.h>
+
+#ifdef LIBRPMI_DEBUG
+#define DPRINTF(msg...)		rpmi_env_printf(msg)
+#else
+#define DPRINTF(msg...)
+#endif
+
+/** Request Forward service group private data */
+struct reqfwd_service_group {
+	const struct rpmi_reqfwd_platform_ops	*ops;
+	void					*ops_priv;
+	rpmi_bool_t				message_retrieved;
+	rpmi_bool_t				notif_enabled;
+	rpmi_bool_t				pending_new_message;
+	rpmi_uint32_t				pending_event_data_len;
+	struct rpmi_transport			*trans;
+	struct rpmi_message			*notif_msg;
+
+	struct rpmi_service_group		group;
+};
+
+static enum rpmi_error rpmi_reqfwd_enable_notification(struct rpmi_service_group *group,
+						       struct rpmi_service *service,
+						       struct rpmi_transport *trans,
+						       rpmi_uint16_t request_datalen,
+						       const rpmi_uint8_t *request_data,
+						       rpmi_uint16_t *response_datalen,
+						       rpmi_uint8_t *response_data)
+{
+	rpmi_uint32_t *resp = (rpmi_uint32_t *)response_data;
+	const rpmi_uint32_t *req = (const rpmi_uint32_t *)request_data;
+	struct reqfwd_service_group *rgrp = group->priv;
+	rpmi_uint32_t event_id, req_state;
+
+	/* Notifications require a P2A channel to deliver events */
+	if (!trans->is_p2a_channel) {
+		resp[0] = rpmi_to_xe32(trans->is_be, RPMI_ERR_NOTSUPP);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	event_id = rpmi_to_xe32(trans->is_be, req[0]);
+	req_state = rpmi_to_xe32(trans->is_be, req[1]);
+
+	DPRINTF("%s: event_id=%d req_state=%d\n", __func__, event_id, req_state);
+
+	/* Validate event ID */
+	if (event_id != RPMI_REQFWD_EVENT_NEW_MESSAGE) {
+		resp[0] = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Validate and process request state */
+	switch (req_state) {
+	case 0: /* Disable */
+		rgrp->notif_enabled = false;
+		rgrp->pending_new_message = false;
+		break;
+	case 1: /* Enable */
+		rgrp->notif_enabled = true;
+		break;
+	case 2: /* Query current state */
+		break;
+	default:
+		resp[0] = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Return current state */
+	resp[0] = rpmi_to_xe32(trans->is_be, RPMI_SUCCESS);
+	resp[1] = rpmi_to_xe32(trans->is_be, rgrp->notif_enabled ? 1U : 0U);
+	*response_datalen = 2 * sizeof(rpmi_uint32_t);
+
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error rpmi_reqfwd_retrieve_current_message(struct rpmi_service_group *group,
+							    struct rpmi_service *service,
+							    struct rpmi_transport *trans,
+							    rpmi_uint16_t request_datalen,
+							    const rpmi_uint8_t *request_data,
+							    rpmi_uint16_t *response_datalen,
+							    rpmi_uint8_t *response_data)
+{
+	rpmi_uint32_t *resp = (rpmi_uint32_t *)response_data;
+	const rpmi_uint32_t *req = (const rpmi_uint32_t *)request_data;
+	struct reqfwd_service_group *rgrp = group->priv;
+	struct rpmi_reqfwd_message msg;
+	rpmi_uint32_t start_index, max_data, remaining, returned;
+	enum rpmi_error ret;
+
+	start_index = rpmi_to_xe32(trans->is_be, req[0]);
+
+	DPRINTF("%s: start_index=%d\n", __func__, start_index);
+
+	/* Get the current forwarded message from platform */
+	ret = rgrp->ops->get_current_message(rgrp->ops_priv, &msg);
+	if (ret != RPMI_SUCCESS) {
+		resp[0] = rpmi_to_xe32(trans->is_be, ret);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Check if we have a message */
+	if (msg.msg_size == 0 || !msg.msg_data) {
+		resp[0] = rpmi_to_xe32(trans->is_be, RPMI_ERR_NO_DATA);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Validate start index */
+	if (start_index >= msg.msg_size) {
+		resp[0] = rpmi_to_xe32(trans->is_be, RPMI_ERR_INVALID_PARAM);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Calculate how much data we can return */
+	max_data = RPMI_MSG_DATA_SIZE(trans->slot_size) - (3 * sizeof(rpmi_uint32_t));
+	remaining = msg.msg_size - start_index;
+	returned = (remaining > max_data) ? max_data : remaining;
+	remaining -= returned;
+
+	/* Fill response */
+	resp[0] = rpmi_to_xe32(trans->is_be, RPMI_SUCCESS);
+	resp[1] = rpmi_to_xe32(trans->is_be, remaining);
+	resp[2] = rpmi_to_xe32(trans->is_be, returned);
+	rpmi_env_memcpy(&resp[3], msg.msg_data + start_index, returned);
+
+	*response_datalen = (3 * sizeof(rpmi_uint32_t)) + returned;
+
+	/* Mark that message has been retrieved */
+	rgrp->message_retrieved = 1;
+
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error rpmi_reqfwd_complete_current_message(struct rpmi_service_group *group,
+							    struct rpmi_service *service,
+							    struct rpmi_transport *trans,
+							    rpmi_uint16_t request_datalen,
+							    const rpmi_uint8_t *request_data,
+							    rpmi_uint16_t *response_datalen,
+							    rpmi_uint8_t *response_data)
+{
+	rpmi_uint32_t *resp = (rpmi_uint32_t *)response_data;
+	struct reqfwd_service_group *rgrp = group->priv;
+	rpmi_uint32_t num_messages = 0;
+	enum rpmi_error ret;
+
+	DPRINTF("%s: request_datalen=%d\n", __func__, request_datalen);
+
+	/* Check if message was retrieved */
+	if (!rgrp->message_retrieved) {
+		resp[0] = rpmi_to_xe32(trans->is_be, RPMI_ERR_NO_DATA);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Complete the current message with response data */
+	ret = rgrp->ops->complete_current_message(rgrp->ops_priv,
+						  request_datalen,
+						  request_data,
+						  &num_messages);
+	if (ret != RPMI_SUCCESS) {
+		resp[0] = rpmi_to_xe32(trans->is_be, ret);
+		*response_datalen = sizeof(rpmi_uint32_t);
+		return RPMI_SUCCESS;
+	}
+
+	/* Reset retrieval flag for next message */
+	rgrp->message_retrieved = 0;
+
+	/* Fill response */
+	resp[0] = rpmi_to_xe32(trans->is_be, RPMI_SUCCESS);
+	resp[1] = rpmi_to_xe32(trans->is_be, num_messages);
+	*response_datalen = 2 * sizeof(rpmi_uint32_t);
+
+	return RPMI_SUCCESS;
+}
+
+static enum rpmi_error rpmi_reqfwd_process_events(struct rpmi_service_group *group)
+{
+	struct reqfwd_service_group *rgrp = group->priv;
+	struct rpmi_transport *trans = rgrp->trans;
+	struct rpmi_message *notif_msg = rgrp->notif_msg;
+	enum rpmi_error rc;
+
+	if (!rgrp->notif_enabled || !rgrp->pending_new_message)
+		return RPMI_SUCCESS;
+
+	notif_msg->header.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD;
+	notif_msg->header.service_id = 0;
+	notif_msg->header.flags = RPMI_MSG_NOTIFICATION;
+	notif_msg->header.token = 0;
+	notif_msg->header.datalen = sizeof(rpmi_uint32_t) + rgrp->pending_event_data_len;
+
+	rc = rpmi_transport_enqueue(trans, RPMI_QUEUE_P2A_REQ, notif_msg);
+	if (rc != RPMI_SUCCESS) {
+		if (rc == RPMI_ERR_IO)
+			return RPMI_ERR_BUSY;
+		DPRINTF("%s: failed to enqueue notification (error %d)\n",
+			__func__, rc);
+		return rc;
+	}
+	rgrp->pending_new_message = false;
+
+	return RPMI_SUCCESS;
+}
+
+static struct rpmi_service rpmi_reqfwd_services[RPMI_REQFWD_SRV_ID_MAX] = {
+	[RPMI_REQFWD_SRV_ENABLE_NOTIFICATION] = {
+		.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+		.min_a2p_request_datalen = 2 * sizeof(rpmi_uint32_t),
+		.process_a2p_request = rpmi_reqfwd_enable_notification,
+	},
+	[RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE] = {
+		.service_id = RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE,
+		.min_a2p_request_datalen = sizeof(rpmi_uint32_t),
+		.process_a2p_request = rpmi_reqfwd_retrieve_current_message,
+	},
+	[RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE] = {
+		.service_id = RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE,
+		.min_a2p_request_datalen = 0,
+		.process_a2p_request = rpmi_reqfwd_complete_current_message,
+	},
+};
+
+struct rpmi_service_group *
+rpmi_service_group_reqfwd_create(const struct rpmi_reqfwd_platform_ops *ops,
+				 void *ops_priv,
+				 struct rpmi_transport *trans)
+{
+	struct reqfwd_service_group *rgrp;
+	struct rpmi_service_group *group;
+
+	if (!ops || !ops->get_current_message || !ops->complete_current_message ||
+	    !trans) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return NULL;
+	}
+
+	/* Allocate request forward group */
+	rgrp = rpmi_env_zalloc(sizeof(*rgrp));
+	if (!rgrp) {
+		DPRINTF("%s: failed to allocate request forward service group instance\n",
+			__func__);
+		return NULL;
+	}
+
+	rgrp->notif_msg = rpmi_env_zalloc(trans->slot_size);
+	if (!rgrp->notif_msg) {
+		DPRINTF("%s: failed to allocate notification message buffer\n",
+			__func__);
+		rpmi_env_free(rgrp);
+		return NULL;
+	}
+
+	rgrp->ops = ops;
+	rgrp->ops_priv = ops_priv;
+	rgrp->message_retrieved = 0;
+	rgrp->notif_enabled = false;
+	rgrp->pending_new_message = false;
+	rgrp->trans = trans;
+
+	group = &rgrp->group;
+	group->name = "reqfwd";
+	group->servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD;
+	group->servicegroup_version =
+		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR, RPMI_SPEC_VERSION_MINOR);
+	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK |
+					RPMI_PRIVILEGE_S_MODE_MASK;
+	group->max_service_id = RPMI_REQFWD_SRV_ID_MAX;
+	group->services = rpmi_reqfwd_services;
+	group->process_events = rpmi_reqfwd_process_events;
+	group->lock = rpmi_env_alloc_lock();
+	group->priv = rgrp;
+
+	DPRINTF("%s: group=%p\n", __func__, group);
+
+	return group;
+}
+
+void rpmi_service_group_reqfwd_destroy(struct rpmi_service_group *group)
+{
+	struct reqfwd_service_group *rgrp;
+
+	if (!group) {
+		DPRINTF("%s: invalid parameters\n", __func__);
+		return;
+	}
+
+	rgrp = group->priv;
+	if (rgrp->notif_msg)
+		rpmi_env_free(rgrp->notif_msg);
+	rpmi_env_free_lock(group->lock);
+	rpmi_env_free(rgrp);
+
+	DPRINTF("%s: group destroyed\n", __func__);
+}
+
+enum rpmi_error rpmi_reqfwd_trigger_new_message(struct rpmi_service_group *group,
+						rpmi_uint32_t event_data_len,
+						const rpmi_uint8_t *event_data)
+{
+	struct reqfwd_service_group *rgrp;
+
+	if (!group || group->servicegroup_id != RPMI_SRVGRP_REQUEST_FORWARD)
+		return RPMI_ERR_INVALID_PARAM;
+
+	rgrp = group->priv;
+
+	if (!rgrp->trans->is_p2a_channel)
+		return RPMI_ERR_NOTSUPP;
+
+	if (event_data_len && !event_data)
+		return RPMI_ERR_INVALID_PARAM;
+
+	/* Clamp to what fits after the event header in one notification slot */
+	rpmi_uint32_t max_event_data = RPMI_MSG_DATA_SIZE(rgrp->trans->slot_size) -
+				       sizeof(rpmi_uint32_t);
+	if (event_data_len > max_event_data)
+		event_data_len = max_event_data;
+
+	/* Round down to 4-byte alignment as required by spec */
+	event_data_len &= ~(rpmi_uint32_t)3;
+
+	rpmi_env_lock(group->lock);
+
+	/* Encode EVENT_HDR: EVENT_ID in bits[23:16], EVENT_DATALEN in bits[15:0] */
+	((rpmi_uint32_t *)rgrp->notif_msg->data)[0] =
+		rpmi_to_xe32(rgrp->trans->is_be,
+			     ((rpmi_uint32_t)RPMI_REQFWD_EVENT_NEW_MESSAGE << 16) | event_data_len);
+	if (event_data_len)
+		rpmi_env_memcpy((rpmi_uint8_t *)rgrp->notif_msg->data +
+				sizeof(rpmi_uint32_t), event_data, event_data_len);
+	rgrp->pending_event_data_len = event_data_len;
+	rgrp->pending_new_message = true;
+
+	rpmi_env_unlock(group->lock);
+
+	return RPMI_SUCCESS;
+}

--- a/test/objects.mk
+++ b/test/objects.mk
@@ -68,3 +68,8 @@ test-elfs-y += test_srvgrp_ras
 
 test_srvgrp_ras-objs-y += test/test_log.o
 test_srvgrp_ras-objs-y += test/test_common.o
+
+test-elfs-y += test_srvgrp_reqfwd
+
+test_srvgrp_reqfwd-objs-y += test/test_log.o
+test_srvgrp_reqfwd-objs-y += test/test_common.o

--- a/test/test_srvgrp_reqfwd.c
+++ b/test/test_srvgrp_reqfwd.c
@@ -1,0 +1,655 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026 SiFive, Inc.
+ */
+
+#include <librpmi.h>
+#include <stdio.h>
+#include "test_common.h"
+#include "test_log.h"
+
+#define TEST_EVENT_ID			RPMI_REQFWD_EVENT_NEW_MESSAGE
+#define TEST_REQUEST_STATE_DISABLE	0x0
+#define TEST_REQUEST_STATE_ENABLE	0x1
+#define TEST_REQUEST_STATE_RETURN	0x2
+
+/* Test request data */
+static rpmi_uint32_t enable_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_ENABLE
+};
+
+static rpmi_uint32_t enable_notif_expdata[] = {
+	RPMI_SUCCESS,
+	TEST_REQUEST_STATE_ENABLE
+};
+
+static rpmi_uint32_t disable_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_DISABLE
+};
+
+static rpmi_uint32_t disable_notif_expdata[] = {
+	RPMI_SUCCESS,
+	TEST_REQUEST_STATE_DISABLE
+};
+
+static rpmi_uint32_t query_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_RETURN
+};
+
+static rpmi_uint32_t query_notif_expdata[] = {
+	RPMI_SUCCESS,
+	TEST_REQUEST_STATE_DISABLE,  /* state = 0 after disable test */
+};
+
+static rpmi_uint32_t invalid_state_reqdata[] = {
+	TEST_EVENT_ID,
+	3,  /* invalid req_state */
+};
+
+static rpmi_uint32_t invalid_state_expdata[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t invalid_event_reqdata[] = {
+	0xFF, /* Invalid event ID */
+	TEST_REQUEST_STATE_ENABLE
+};
+
+static rpmi_uint32_t invalid_event_expdata[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+/* Mock forwarded message data */
+static rpmi_uint8_t mock_forwarded_msg[] = {
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+};
+
+struct test_reqfwd_scenario_config {
+	enum rpmi_privilege_level privilege_level;
+	struct rpmi_service_group *grp;
+};
+
+/* Mock state */
+static rpmi_bool_t mock_has_message;
+static rpmi_uint32_t mock_num_pending;
+
+/* Platform callback: get current message */
+static enum rpmi_error test_reqfwd_get_current_message(void *priv,
+						       struct rpmi_reqfwd_message *msg)
+{
+	if (!mock_has_message)
+		return RPMI_ERR_NO_DATA;
+
+	msg->msg_size = sizeof(mock_forwarded_msg);
+	msg->msg_data = mock_forwarded_msg;
+
+	return RPMI_SUCCESS;
+}
+
+/* Platform callback: complete current message */
+static enum rpmi_error test_reqfwd_complete_current_message(void *priv,
+							    rpmi_uint32_t resp_data_len,
+							    const rpmi_uint8_t *resp_data,
+							    rpmi_uint32_t *num_messages)
+{
+	mock_has_message = 0;
+	*num_messages = mock_num_pending;
+
+	return RPMI_SUCCESS;
+}
+
+static struct rpmi_reqfwd_platform_ops test_reqfwd_ops = {
+	.get_current_message = test_reqfwd_get_current_message,
+	.complete_current_message = test_reqfwd_complete_current_message,
+};
+
+static rpmi_uint32_t retrieve_reqdata[] = {
+	0,  /* start_index = 0 */
+};
+
+static rpmi_uint32_t retrieve_no_msg_expdata[] = {
+	RPMI_ERR_NO_DATA,
+};
+
+static rpmi_uint32_t complete_msg_expdata[] = {
+	RPMI_SUCCESS,
+	0,  /* num_messages = mock_num_pending = 0 */
+};
+
+static rpmi_uint32_t complete_no_retrieve_expdata[] = {
+	RPMI_ERR_NO_DATA,
+};
+
+static rpmi_uint32_t retrieve_reqdata_offset[] = {
+	8,  /* start_index = 8 */
+};
+
+static rpmi_uint16_t test_retrieve_msg_offset_init_expected_data(struct rpmi_test_scenario *scene,
+								 struct rpmi_test *test, void *data,
+								 rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *exp = (rpmi_uint32_t *)data;
+	rpmi_uint16_t offset = 8;
+	rpmi_uint16_t returned = sizeof(mock_forwarded_msg) - offset;
+
+	exp[0] = RPMI_SUCCESS;
+	exp[1] = 0;  /* remaining */
+	exp[2] = returned;
+	rpmi_env_memcpy(&exp[3], mock_forwarded_msg + offset, returned);
+
+	return 3 * sizeof(rpmi_uint32_t) + returned;
+}
+
+static int test_retrieve_no_msg_init(struct rpmi_test_scenario *scene,
+				     struct rpmi_test *test)
+{
+	mock_has_message = 0;
+	return 0;
+}
+
+static int test_retrieve_with_msg_init(struct rpmi_test_scenario *scene,
+				       struct rpmi_test *test)
+{
+	mock_has_message = 1;
+	return 0;
+}
+
+static rpmi_uint16_t test_retrieve_msg_init_expected_data(struct rpmi_test_scenario *scene,
+							  struct rpmi_test *test, void *data,
+							  rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *exp = (rpmi_uint32_t *)data;
+
+	exp[0] = RPMI_SUCCESS;
+	exp[1] = 0;  /* remaining */
+	exp[2] = sizeof(mock_forwarded_msg);  /* returned */
+	rpmi_env_memcpy(&exp[3], mock_forwarded_msg, sizeof(mock_forwarded_msg));
+
+	return 3 * sizeof(rpmi_uint32_t) + sizeof(mock_forwarded_msg);
+}
+
+static int test_reqfwd_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct test_reqfwd_scenario_config *config;
+	enum rpmi_privilege_level privilege_level;
+	struct rpmi_service_group *grp;
+	int ret;
+
+	if (!scene)
+		return RPMI_ERR_INVALID_PARAM;
+
+	config = scene->priv;
+	if (!config)
+		return RPMI_ERR_INVALID_PARAM;
+
+	if (scene->shm || scene->shmem || scene->xport || scene->cntx)
+		return RPMI_ERR_ALREADY;
+
+	scene->shm = rpmi_env_zalloc(scene->shm_size);
+	if (!scene->shm)
+		return RPMI_ERR_FAILED;
+
+	scene->shmem = rpmi_shmem_create("test_shmem",
+					 (unsigned long)scene->shm,
+					 scene->shm_size,
+					 &rpmi_shmem_simple_ops, NULL);
+	if (!scene->shmem) {
+		printf("%s: failed to create test rpmi_shmem\n ", __func__);
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->xport = rpmi_transport_shmem_create("test_transport",
+						   scene->slot_size,
+						   ((scene->shm_size * 3) / 4) / 2,
+						   ((scene->shm_size * 1) / 4) / 2,
+						   scene->shmem);
+	if (!scene->xport) {
+		printf("%s: failed to create test rpmi_transport\n ", __func__);
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	privilege_level = config->privilege_level;
+	scene->cntx = rpmi_context_create("test_context", scene->xport,
+					  scene->max_num_groups,
+					  privilege_level,
+					  scene->base.plat_info_len,
+					  scene->base.plat_info);
+	if (!scene->cntx) {
+		printf("%s: failed to create test rpmi_context\n ", __func__);
+		ret = RPMI_ERR_FAILED;
+		goto fail_cleanup;
+	}
+
+	grp = rpmi_service_group_reqfwd_create(&test_reqfwd_ops, NULL, scene->xport);
+	if (!grp) {
+		printf("Failed to create Request Forward service group\n");
+		ret = RPMI_ERR_FAILED;
+		goto fail_cleanup;
+	}
+
+	ret = rpmi_context_add_group(scene->cntx, grp);
+	if (ret) {
+		printf("Failed to add Request Forward service group\n");
+		rpmi_service_group_reqfwd_destroy(grp);
+		goto fail_cleanup;
+	}
+
+	config->grp = grp;
+	scene->token_sequence = 0;
+	return 0;
+
+fail_cleanup:
+	test_scenario_default_cleanup(scene);
+	return ret;
+}
+
+static int test_reqfwd_scenario_cleanup(struct rpmi_test_scenario *scene)
+{
+	struct test_reqfwd_scenario_config *config;
+
+	if (!scene)
+		return RPMI_ERR_INVALID_PARAM;
+
+	config = scene->priv;
+	if (config)
+		config->grp = NULL;
+
+	return test_scenario_default_cleanup(scene);
+}
+
+static rpmi_uint8_t test_notif_event_data[] = { 0xAB, 0xCD, 0xEF, 0x01 };
+
+static int test_p2a_notif_run(struct rpmi_test_scenario *scene,
+			      struct rpmi_test *test,
+			      struct rpmi_message *msg)
+{
+	struct test_reqfwd_scenario_config *config = scene->priv;
+
+	return rpmi_reqfwd_trigger_new_message(config->grp, 0, NULL);
+}
+
+static int test_p2a_notif_with_data_run(struct rpmi_test_scenario *scene,
+					struct rpmi_test *test,
+					struct rpmi_message *msg)
+{
+	struct test_reqfwd_scenario_config *config = scene->priv;
+
+	return rpmi_reqfwd_trigger_new_message(config->grp,
+					       sizeof(test_notif_event_data),
+					       test_notif_event_data);
+}
+
+static rpmi_uint16_t test_notif_with_data_init_expected_data(struct rpmi_test_scenario *scene,
+							     struct rpmi_test *test, void *data,
+							     rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *exp_u32 = (rpmi_uint32_t *)data;
+	rpmi_uint8_t *exp_u8 = (rpmi_uint8_t *)data;
+
+	exp_u32[0] = ((rpmi_uint32_t)RPMI_REQFWD_EVENT_NEW_MESSAGE << 16) |
+		     sizeof(test_notif_event_data);
+	rpmi_env_memcpy(exp_u8 + sizeof(rpmi_uint32_t), test_notif_event_data,
+			sizeof(test_notif_event_data));
+	return sizeof(rpmi_uint32_t) + sizeof(test_notif_event_data);
+}
+
+static void test_p2a_notif_wait(struct rpmi_test_scenario *scene,
+				struct rpmi_test *test,
+				struct rpmi_message *msg)
+{
+	int result = -1;
+
+	rpmi_env_memset(msg, 0, scene->slot_size);
+	while (result != RPMI_SUCCESS)
+		result = rpmi_transport_dequeue(scene->xport,
+						RPMI_QUEUE_P2A_REQ, msg);
+}
+
+static rpmi_uint32_t notif_expdata[] = {
+	(rpmi_uint32_t)RPMI_REQFWD_EVENT_NEW_MESSAGE << 16,
+};
+
+static rpmi_uint32_t reenable_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_ENABLE
+};
+
+static rpmi_uint32_t reenable_notif_expdata[] = {
+	RPMI_SUCCESS,
+	TEST_REQUEST_STATE_ENABLE
+};
+
+static struct test_reqfwd_scenario_config reqfwd_m_mode_config = {
+	.privilege_level = RPMI_PRIVILEGE_M_MODE,
+};
+
+static struct test_reqfwd_scenario_config reqfwd_s_mode_config = {
+	.privilege_level = RPMI_PRIVILEGE_S_MODE,
+};
+
+static int test_reqfwd_group_allows_s_mode(void)
+{
+	struct rpmi_transport dummy_xport = { .slot_size = RPMI_SLOT_SIZE };
+	struct rpmi_service_group *grp;
+	int ret = 0;
+
+	grp = rpmi_service_group_reqfwd_create(&test_reqfwd_ops, NULL,
+					       &dummy_xport);
+	if (!grp) {
+		printf("%s: failed to create group\n", __func__);
+		return RPMI_ERR_FAILED;
+	}
+
+	if (!(grp->privilege_level_bitmap & RPMI_PRIVILEGE_S_MODE_MASK)) {
+		printf("%s: FAIL - S-mode not allowed\n", __func__);
+		ret = RPMI_ERR_FAILED;
+	} else {
+		printf("%s: PASS\n", __func__);
+	}
+
+	rpmi_service_group_reqfwd_destroy(grp);
+	return ret;
+}
+
+static struct rpmi_test_scenario scenario_reqfwd_default = {
+	.name = "Request Forward Service Group",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &reqfwd_m_mode_config,
+
+	.init = test_reqfwd_scenario_init,
+	.cleanup = test_reqfwd_scenario_cleanup,
+
+	.num_tests = 13,
+	.tests = {
+		{
+			.name = "ENABLE NOTIFICATION TEST (enable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata,
+				.request_data_len = sizeof(enable_notif_reqdata),
+				.expected_data = enable_notif_expdata,
+				.expected_data_len = sizeof(enable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "ENABLE NOTIFICATION TEST (disable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = disable_notif_reqdata,
+				.request_data_len = sizeof(disable_notif_reqdata),
+				.expected_data = disable_notif_expdata,
+				.expected_data_len = sizeof(disable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "ENABLE NOTIFICATION TEST (query state)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = query_notif_reqdata,
+				.request_data_len = sizeof(query_notif_reqdata),
+				.expected_data = query_notif_expdata,
+				.expected_data_len = sizeof(query_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "ENABLE NOTIFICATION TEST (invalid state)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = invalid_state_reqdata,
+				.request_data_len = sizeof(invalid_state_reqdata),
+				.expected_data = invalid_state_expdata,
+				.expected_data_len = sizeof(invalid_state_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "ENABLE NOTIFICATION TEST (invalid event)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = invalid_event_reqdata,
+				.request_data_len = sizeof(invalid_event_reqdata),
+				.expected_data = invalid_event_expdata,
+				.expected_data_len = sizeof(invalid_event_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RETRIEVE CURRENT MESSAGE TEST (no message available)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = retrieve_reqdata,
+				.request_data_len = sizeof(retrieve_reqdata),
+				.expected_data = retrieve_no_msg_expdata,
+				.expected_data_len = sizeof(retrieve_no_msg_expdata),
+			},
+			.init = test_retrieve_no_msg_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RETRIEVE CURRENT MESSAGE TEST (message, start_index=0)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = retrieve_reqdata,
+				.request_data_len = sizeof(retrieve_reqdata),
+			},
+			.init = test_retrieve_with_msg_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_retrieve_msg_init_expected_data,
+		},
+		{
+			.name = "RETRIEVE CURRENT MESSAGE TEST (message, start_index=8)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = retrieve_reqdata_offset,
+				.request_data_len = sizeof(retrieve_reqdata_offset),
+			},
+			.init = test_retrieve_with_msg_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_retrieve_msg_offset_init_expected_data,
+		},
+		{
+			.name = "COMPLETE CURRENT MESSAGE TEST (after retrieve)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = complete_msg_expdata,
+				.expected_data_len = sizeof(complete_msg_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "COMPLETE CURRENT MESSAGE TEST (without prior retrieve)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = complete_no_retrieve_expdata,
+				.expected_data_len = sizeof(complete_no_retrieve_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "NOTIFICATION: re-enable for delivery test",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = reenable_notif_reqdata,
+				.request_data_len = sizeof(reenable_notif_reqdata),
+				.expected_data = reenable_notif_expdata,
+				.expected_data_len = sizeof(reenable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "NOTIFICATION: trigger new_message and verify P2A",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.flags = RPMI_MSG_POSTED_REQUEST,
+				.expected_data = notif_expdata,
+				.expected_data_len = sizeof(notif_expdata),
+			},
+			.run = test_p2a_notif_run,
+			.wait = test_p2a_notif_wait,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "NOTIFICATION: trigger with event data, P2A",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.flags = RPMI_MSG_POSTED_REQUEST,
+			},
+			.run = test_p2a_notif_with_data_run,
+			.wait = test_p2a_notif_wait,
+			.init_expected_data = test_notif_with_data_init_expected_data,
+		},
+	},
+};
+
+static struct rpmi_test_scenario scenario_reqfwd_s_mode = {
+	.name = "Request Forward Service Group (S-mode)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &reqfwd_s_mode_config,
+
+	.init = test_reqfwd_scenario_init,
+	.cleanup = test_reqfwd_scenario_cleanup,
+
+	.num_tests = 6,
+	.tests = {
+		{
+			.name = "ENABLE NOTIFICATION TEST (S-mode, enable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata,
+				.request_data_len = sizeof(enable_notif_reqdata),
+				.expected_data = enable_notif_expdata,
+				.expected_data_len = sizeof(enable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "ENABLE NOTIFICATION TEST (S-mode, disable)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = disable_notif_reqdata,
+				.request_data_len = sizeof(disable_notif_reqdata),
+				.expected_data = disable_notif_expdata,
+				.expected_data_len = sizeof(disable_notif_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RETRIEVE CURRENT MESSAGE TEST (S-mode, no message)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = retrieve_reqdata,
+				.request_data_len = sizeof(retrieve_reqdata),
+				.expected_data = retrieve_no_msg_expdata,
+				.expected_data_len = sizeof(retrieve_no_msg_expdata),
+			},
+			.init = test_retrieve_no_msg_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RETRIEVE CURRENT MSG TEST (S-mode, message)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_RETRIEVE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = retrieve_reqdata,
+				.request_data_len = sizeof(retrieve_reqdata),
+			},
+			.init = test_retrieve_with_msg_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_retrieve_msg_init_expected_data,
+		},
+		{
+			.name = "COMPLETE CURRENT MSG TEST (S-mode, after retrieve)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = complete_msg_expdata,
+				.expected_data_len = sizeof(complete_msg_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "COMPLETE CURRENT MSG TEST (S-mode, no retrieve)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_REQUEST_FORWARD,
+				.service_id = RPMI_REQFWD_SRV_COMPLETE_CURRENT_MESSAGE,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = complete_no_retrieve_expdata,
+				.expected_data_len = sizeof(complete_no_retrieve_expdata),
+			},
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+	},
+};
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	printf("Test Request Forward Service Group\n");
+
+	ret = test_reqfwd_group_allows_s_mode();
+	if (ret)
+		return ret;
+
+	ret = test_scenario_execute(&scenario_reqfwd_default);
+	ret |= test_scenario_execute(&scenario_reqfwd_s_mode);
+
+	return ret;
+}


### PR DESCRIPTION
This PR implements the REQUEST_FORWARD service group as specified in RPMI specification Section 4.13, providing services to retrieve and process RPMI request messages forwarded by the platform microcontroller.

### Overview
The REQUEST_FORWARD service group enables application processors to retrieve and process RPMI request messages that are forwarded by platform firmware from other RPMI clients. This supports use-cases like forwarding RPMI messages between system-level partitions/domains using the SBI MPXY extension.

### Changes

**1. Library Implementation ( lib/rpmi_service_group_reqfwd.c )**

Implements all 3 services defined in the RPMI specification:

#### Services
- **REQFWD_ENABLE_NOTIFICATION** (0x01)
  - Enable, disable, or query NEW_MESSAGE event notifications
  - Validates event ID and request state parameters
  - Returns current notification state

- **REQFWD_RETRIEVE_CURRENT_MESSAGE** (0x02)
  - Retrieves the current (oldest) forwarded RPMI message from platform queue
  - Handles START_INDEX for pagination of large messages
  - Returns REMAINING and RETURNED byte counts
  - Validates start index bounds

- **REQFWD_COMPLETE_CURRENT_MESSAGE** (0x03)
  - Completes processing of the current forwarded message
  - Accepts optional response data to send back to original requester
  - Returns NUM_MESSAGES (count of remaining messages in queue)
  - Validates that a message was previously retrieved

**Features**
- **Pagination Support**: Automatically handles large messages exceeding transport slot size
- **State Management**: Prevents completing a message without prior retrieval
- **Platform HAL Interface**: Clean callback interface for message retrieval and completion
- **Endianness Handling**: Proper  rpmi_to_xe32()  usage for transport compatibility
- **Memory Safety**: Bounds checking, NULL pointer validation, overflow protection
- **Error Handling**: Comprehensive validation with appropriate error codes

**2. Tests:**

test/test_srvgrp_reqfwd.c  - REQUEST_FORWARD test suite (new, 173 lines)
test/objects.mk  - Test build configuration

### Testing

- [x] `make` - builds successfully without warnings
- [x] `make check` - all tests pass
- [x] `make LIBRPMI_TEST=y` - builds with tests successfully

All existing tests continue to pass. New REQUEST_FORWARD functionality is verified through the test suite.

Compliance
Implements REQUEST_FORWARD Service Group (0x000D) as specified in the RISC-V RPMI specification Section 4.13.