### PR TITLE
test: pass NULL as ops_priv in sysreset test scenarios

### DIFF
--- a/test/test_srvgrp_sysreset.c
+++ b/test/test_srvgrp_sysreset.c
@@ -155,7 +155,7 @@ static int test_sysreset_scenario_init(struct rpmi_test_scenario *scene)
 	grp = rpmi_service_group_sysreset_create(
 				sizeof(test_rpmi_reset_types) / sizeof(rpmi_uint32_t),
 				(const rpmi_uint32_t *)&test_rpmi_reset_types,
-				&rpmi_reset_ops, scene->cntx);
+				&rpmi_reset_ops, NULL);
 	rpmi_context_add_group(scene->cntx, grp);
 	return 0;
 }


### PR DESCRIPTION
The ops_priv parameter in rpmi_service_group_sysreset_create() is intended for private data that the platform (low-level layer) wants the RPMI infrastructure to pass back to its platform callbacks. Passing scene->cntx (an rpmi_context object belonging to the RPMI middle layer) was semantically incorrect.

The test platform callbacks do not use the priv argument at all — they track state through static globals — so the correct value is NULL.
