### PR TITLE
docs: fix Doxygen group separation in librpmi.h

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -2119,6 +2119,10 @@ enum rpmi_error rpmi_mm_service_register(struct rpmi_service_group *group,
 					 rpmi_uint32_t num_entries,
 					 struct rpmi_mm_service *iplist);
 
+/** @} */
+
+/****************************************************************************/
+
 /**
  * \defgroup LIBRPMI_LOGGINGSRVGRP_INTERFACE RPMI Logging Service Group Library Interface
  * @brief Global functions and data structures implemented by the RPMI library


### PR DESCRIPTION
Close the previous Doxygen group before starting the RPMI Logging Service Group documentation block.

Fixes: be3e635d73843e68a0523474e6c82fe3f96fe05e ("lib: Add Logging service group")