### PR TITLE
build: add GitHub Actions CI workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,69 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install checkpatch
+        run: |
+          wget -q https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
+          wget -q https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+          wget -q https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch
+          chmod +x checkpatch.pl
+      - name: Run checkpatch
+        run: |
+          git format-patch --no-merges origin/${{ github.base_ref }}..HEAD --stdout \
+            | ./checkpatch.pl --no-tree --ignore FILE_PATH_CHANGES
+
+  commit-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate commit message prefixes
+        run: |
+          pattern='^(lib|include|test|docs|debian|build):'
+          failed=0
+          while IFS= read -r line; do
+            sha="${line%% *}"
+            subject="${line#* }"
+            if ! echo "$subject" | grep -qE "$pattern"; then
+              echo "FAIL [$sha]: $subject"
+              failed=1
+            fi
+          done < <(git log --no-merges --format="%h %s" origin/${{ github.base_ref }}..HEAD)
+          if [ $failed -ne 0 ]; then
+            echo "Commit subjects must start with one of: lib: include: test: docs: debian: build:"
+            exit 1
+          fi
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'include/**'
+      - name: Install doxygen
+        if: steps.changes.outputs.docs == 'true'
+        run: sudo apt-get install -y doxygen graphviz
+      - name: Build docs
+        if: steps.changes.outputs.docs == 'true'
+        run: make htmldocs

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,27 @@
+name: Unit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  unit-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    steps:
+      - uses: actions/checkout@v4
+      - shell: bash
+        timeout-minutes: 2
+        run: |
+          make -j check LIBRPMI_TEST=y

--- a/Makefile
+++ b/Makefile
@@ -306,11 +306,14 @@ ifeq ($(install_root_dir),$(install_root_dir_default))
 	$(CMD_PREFIX)rm -rf $(install_root_dir_default)
 endif
 
-.PHONY: docs
-docs:
+.PHONY: htmldocs
+htmldocs:
 	$(CMD_PREFIX)mkdir -p $(docs_dir)
 	$(CMD_PREFIX)cat docs/doxygen/Doxyfile | sed -e "s#@@SRC_DIR@@#.#" -e "s#@@BUILD_DIR@@#$(build_dir)#" > $(docs_dir)/Doxyfile
 	$(CMD_PREFIX)doxygen $(docs_dir)/Doxyfile
+
+.PHONY: docs
+docs: htmldocs
 	$(CMD_PREFIX)make -C $(docs_dir)/latex
 
 # Rule for make cleandocs


### PR DESCRIPTION
## Summary

- Add `unit.yml`: runs `make check` on ubuntu-24.04 and macos-15 on push/PR to main.
  Runners are pinned (not `*-latest`) to avoid silent breakage when GitHub shifts a runner OS.
- Add `pr-checks.yml`: three PR-only jobs:
  - **checkpatch** — runs `checkpatch.pl --no-tree` over all non-merge commits; covers DCO
    (Signed-off-by presence/correctness) and kernel-style code hygiene. Replaces a hand-rolled
    grep-based DCO check. `FILE_PATH_CHANGES` is suppressed (kernel MAINTAINERS convention,
    not applicable here).
  - **commit-format** — validates that commit subjects start with one of the project's required
    prefixes: `lib:` `include:` `test:` `docs:` `debian:` `build:`. checkpatch.pl has no
    concept of project-specific prefixes so this check is kept separate.
  - **docs** — runs `make docs` only when `docs/**` or `include/**` files change, gated via
    `dorny/paths-filter`.
 - Add `htmldocs` Makefile target: runs doxygen without the LaTeX/PDF step. The existing `docs`
  target depends on `htmldocs` so the full PDF build is preserved for local use. CI uses
  `htmldocs` to avoid requiring `pdflatex` on the runner.

## Notes

- The project uses Linux kernel commit style, not Conventional Commits — off-the-shelf
  `commitlint` would reject valid commits, hence the custom prefix check.
- checkpatch.pl is downloaded fresh from `torvalds/linux` at CI runtime (no vendored copy).

## Test plan

- [x] Push a commit missing `Signed-off-by:` — checkpatch job should fail
<img width="717" height="391" alt="image" src="https://github.com/user-attachments/assets/eb2eda4b-75db-4927-94df-d707027d7dae" />

- [x] Push a commit with a subject that lacks a required prefix — commit-format job should fail
<img width="734" height="430" alt="image" src="https://github.com/user-attachments/assets/374f1ae4-5670-4a03-a07b-94c73e0a6565" />

- [x] Push a docs change — docs job should run and pass
<img width="431" height="74" alt="image" src="https://github.com/user-attachments/assets/ff5d1063-6ab3-4e30-88b3-159906f381c5" />

- [x] Push a non-docs change — docs job should be skipped
<img width="326" height="389" alt="image" src="https://github.com/user-attachments/assets/5021620a-9e41-42ba-8dac-50fdcb941b08" />

- [x] All jobs green on a well-formed PR
<img width="748" height="450" alt="image" src="https://github.com/user-attachments/assets/e7b5df05-154d-4b25-8bbe-69e338262d77" />
