### PR TITLE
lib,test: align logging service and add coverage

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -198,7 +198,7 @@ enum rpmi_servicegroup_id {
 	RPMI_SRVGRP_MANAGEMENT_MODE	= 0x000B,
 	RPMI_SRVGRP_RAS_AGENT		= 0x000C,
 	RPMI_SRVGRP_REQUEST_FORWARD	= 0x000D,
-	RPMI_SRVGRP_LOGGING			= 0x000E,
+	RPMI_SRVGRP_LOGGING		= 0x000E,
 	RPMI_SRVGRP_ID_MAX_COUNT,
 
 	/* Reserved range for service groups */
@@ -373,7 +373,7 @@ enum rpmi_mm_service_id {
 /** RPMI LOGGING ServiceGroup Service IDs */
 enum rpmi_logging_service_id {
 	RPMI_LOGGING_SRV_ENABLE_NOTIFICATION = 0x01,
-	RPMI_LOGGING_SRV_SET_CONFIG = 0x02,
+	RPMI_LOGGING_SRV_LOG_DATA = 0x02,
 	RPMI_LOGGING_SRV_ID_MAX,
 };
 
@@ -2132,9 +2132,9 @@ enum rpmi_error rpmi_mm_service_register(struct rpmi_service_group *group,
 
 /** Platform specific logging operations */
 struct rpmi_logging_platform_ops {
-	enum rpmi_error (*do_set_state)(void *priv, rpmi_uint32_t log_type,
-					rpmi_uint32_t datalen_bytes,
-					const void *data);
+	enum rpmi_error (*log_data)(void *priv, rpmi_uint32_t log_type,
+				    rpmi_uint32_t num_words,
+				    const rpmi_uint32_t *words);
 };
 
 /**

--- a/lib/rpmi_service_group_logging.c
+++ b/lib/rpmi_service_group_logging.c
@@ -20,61 +20,82 @@ struct rpmi_logging_group {
 };
 
 static enum rpmi_error
-rpmi_logging_set_state(struct rpmi_logging_group *sglogging,
-		      rpmi_uint32_t log_type, rpmi_uint32_t datalen_bytes,
-		      const void *data)
+rpmi_logging_log_data(struct rpmi_logging_group *sglogging,
+		      rpmi_uint32_t log_type, rpmi_uint32_t num_words,
+		      const rpmi_uint32_t *words)
 {
 	enum rpmi_error ret;
 
-	ret = sglogging->ops->do_set_state(sglogging->ops_priv, log_type,
-					   datalen_bytes, data);
+	ret = sglogging->ops->log_data(sglogging->ops_priv, log_type,
+				       num_words, words);
 
 	return ret;
 }
 
 static enum rpmi_error
-rpmi_logging_sg_set_config(struct rpmi_service_group *group,
-			   struct rpmi_service *service,
-			   struct rpmi_transport *trans,
-			   rpmi_uint16_t request_datalen,
-			   const rpmi_uint8_t *request_data,
-			   rpmi_uint16_t *response_datalen,
-			   rpmi_uint8_t *response_data)
+rpmi_logging_sg_log_data(struct rpmi_service_group *group,
+			 struct rpmi_service *service,
+			 struct rpmi_transport *trans,
+			 rpmi_uint16_t request_datalen,
+			 const rpmi_uint8_t *request_data,
+			 rpmi_uint16_t *response_datalen,
+			 rpmi_uint8_t *response_data)
 {
-	enum rpmi_error status;
+	const rpmi_uint32_t *req = (const rpmi_uint32_t *)request_data;
+	rpmi_uint32_t log_type, num_words, remaining_words, i;
 	struct rpmi_logging_group *logginggrp = group->priv;
 	rpmi_uint32_t *resp = (void *)response_data;
-	rpmi_uint32_t log_type;
-	const rpmi_uint8_t *data;
-	rpmi_uint32_t datalen_bytes;
+	rpmi_uint32_t *words = NULL;
+	enum rpmi_error status;
 
-	if (request_datalen < sizeof(rpmi_uint32_t)) {
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
-		*response_datalen = sizeof(*resp);
-		return RPMI_SUCCESS;
+	if (request_datalen < 2 * sizeof(*req) ||
+	    (request_datalen - (2 * sizeof(*req))) % sizeof(*req)) {
+		status = RPMI_ERR_INVALID_PARAM;
+		goto done;
 	}
 
-	log_type = rpmi_to_xe32(trans->is_be,
-				((const rpmi_uint32_t *)request_data)[0]);
-	data = request_data + sizeof(log_type);
-	datalen_bytes = request_datalen - sizeof(log_type);
+	log_type = rpmi_to_xe32(trans->is_be, req[0]);
+	num_words = rpmi_to_xe32(trans->is_be, req[1]);
+	remaining_words = (request_datalen - (2 * sizeof(*req))) / sizeof(*req);
 
-	/* change logging config synchronously */
-	status = rpmi_logging_set_state(logginggrp, log_type, datalen_bytes,
-					data);
+	if (num_words != remaining_words) {
+		status = RPMI_ERR_INVALID_PARAM;
+		goto done;
+	}
+
+	if (num_words) {
+		words = rpmi_env_zalloc(num_words * sizeof(*words));
+		if (!words) {
+			status = RPMI_ERR_FAILED;
+			goto done;
+		}
+
+		for (i = 0; i < num_words; i++)
+			words[i] = rpmi_to_xe32(trans->is_be, req[2 + i]);
+	}
+
+	status = rpmi_logging_log_data(logginggrp, log_type, num_words, words);
+
+	if (words)
+		rpmi_env_free(words);
+
+done:
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)status);
-
 	*response_datalen = sizeof(*resp);
 
 	return RPMI_SUCCESS;
 }
 
 static struct rpmi_service rpmi_logging_services[RPMI_LOGGING_SRV_ID_MAX] = {
-	[RPMI_LOGGING_SRV_SET_CONFIG] = {
-		.service_id = RPMI_LOGGING_SRV_SET_CONFIG,
-		.min_a2p_request_datalen = 16,
-		.process_a2p_request = rpmi_logging_sg_set_config,
+	[RPMI_LOGGING_SRV_ENABLE_NOTIFICATION] = {
+		.service_id = RPMI_LOGGING_SRV_ENABLE_NOTIFICATION,
+		.min_a2p_request_datalen = 2 * sizeof(rpmi_uint32_t),
+		.process_a2p_request = NULL,
+	},
+	[RPMI_LOGGING_SRV_LOG_DATA] = {
+		.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+		.min_a2p_request_datalen = 2 * sizeof(rpmi_uint32_t),
+		.process_a2p_request = rpmi_logging_sg_log_data,
 	},
 };
 
@@ -86,7 +107,7 @@ struct rpmi_service_group *rpmi_service_group_logging_create(
 	struct rpmi_logging_group *sglogging;
 
 	/* All critical parameters should be non-NULL */
-	if (!ops || !ops->do_set_state) {
+	if (!ops || !ops->log_data) {
 		DPRINTF("%s: invalid parameters\n", __func__);
 		return NULL;
 	}
@@ -108,8 +129,9 @@ struct rpmi_service_group *rpmi_service_group_logging_create(
 	group->servicegroup_version =
 		RPMI_BASE_VERSION(RPMI_SPEC_VERSION_MAJOR,
 				  RPMI_SPEC_VERSION_MINOR);
-	/* Allowed only for M-mode RPMI context */
-	group->privilege_level_bitmap = RPMI_PRIVILEGE_M_MODE_MASK;
+	/* Allowed for both M-mode and S-mode RPMI context */
+	group->privilege_level_bitmap =
+		RPMI_PRIVILEGE_M_MODE_MASK | RPMI_PRIVILEGE_S_MODE_MASK;
 	group->max_service_id = RPMI_LOGGING_SRV_ID_MAX;
 	group->services = rpmi_logging_services;
 	group->lock = rpmi_env_alloc_lock();
@@ -125,5 +147,6 @@ void rpmi_service_group_logging_destroy(struct rpmi_service_group *group)
 		return;
 	}
 
+	rpmi_env_free_lock(group->lock);
 	rpmi_env_free(group->priv);
 }

--- a/test/objects.mk
+++ b/test/objects.mk
@@ -58,3 +58,8 @@ test-elfs-y += test_srvgrp_performance
 
 test_srvgrp_performance-objs-y += test/test_log.o
 test_srvgrp_performance-objs-y += test/test_common.o
+
+test-elfs-y += test_srvgrp_logging
+
+test_srvgrp_logging-objs-y += test/test_log.o
+test_srvgrp_logging-objs-y += test/test_common.o

--- a/test/test_srvgrp_logging.c
+++ b/test/test_srvgrp_logging.c
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026 Qualcomm Inc.
+ */
+
+#include <librpmi.h>
+#include <stdio.h>
+#include "test_common.h"
+#include "test_log.h"
+
+#define TEST_LOG_TYPE			0x5a
+#define TEST_LOG_TYPE_DENIED		0xd0
+#define TEST_LOG_WORD0			0x11223344
+#define TEST_LOG_WORD1			0x55667788
+#define TEST_LOG_MAX_WORDS		4
+#define TEST_EDK2_STATUS_LOG_TYPE	0x0
+#define TEST_EDK2_STATUS_CODE_TYPE	0x1
+#define TEST_EDK2_PROGRESS_CODE		0x03040003
+#define TEST_EDK2_BOOT_CODE		0x02011001
+#define TEST_EDK2_INSTANCE		0x0
+#define TEST_EVENT_ID			0x0
+#define TEST_REQUEST_STATE_ENABLE	0x1
+
+struct test_logging_capture {
+	rpmi_uint32_t call_count;
+	rpmi_uint32_t log_type;
+	rpmi_uint32_t num_words;
+	rpmi_uint32_t words[TEST_LOG_MAX_WORDS];
+};
+
+struct test_logging_expect {
+	rpmi_uint32_t call_count;
+	rpmi_uint32_t log_type;
+	rpmi_uint32_t num_words;
+	const rpmi_uint32_t *words;
+};
+
+struct test_logging_scenario_config {
+	enum rpmi_privilege_level privilege_level;
+	rpmi_bool_t is_be;
+	struct rpmi_service_group *grp;
+};
+
+static struct test_logging_capture test_logging_capture;
+
+static rpmi_uint32_t enable_notif_reqdata[] = {
+	TEST_EVENT_ID,
+	TEST_REQUEST_STATE_ENABLE,
+};
+
+static rpmi_uint32_t log_data_reqdata[] = {
+	TEST_LOG_TYPE,
+	2,
+	TEST_LOG_WORD0,
+	TEST_LOG_WORD1,
+};
+
+static rpmi_uint32_t log_data_short_reqdata[] = {
+	TEST_LOG_TYPE,
+};
+
+static rpmi_uint32_t log_data_zero_words_reqdata[] = {
+	TEST_LOG_TYPE,
+	0,
+};
+
+static rpmi_uint32_t log_data_bad_count_reqdata[] = {
+	TEST_LOG_TYPE,
+	3,
+	TEST_LOG_WORD0,
+	TEST_LOG_WORD1,
+};
+
+static rpmi_uint8_t log_data_unaligned_reqdata[] = {
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+};
+
+static rpmi_uint32_t log_data_denied_reqdata[] = {
+	TEST_LOG_TYPE_DENIED,
+	0,
+};
+
+static rpmi_uint32_t log_data_denied_words_reqdata[] = {
+	TEST_LOG_TYPE_DENIED,
+	2,
+	TEST_LOG_WORD0,
+	TEST_LOG_WORD1,
+};
+
+static rpmi_uint32_t edk2_progress_reqdata[] = {
+	TEST_EDK2_STATUS_LOG_TYPE,
+	3,
+	TEST_EDK2_STATUS_CODE_TYPE,
+	TEST_EDK2_PROGRESS_CODE,
+	TEST_EDK2_INSTANCE,
+};
+
+static rpmi_uint32_t edk2_boot_reqdata[] = {
+	TEST_EDK2_STATUS_LOG_TYPE,
+	3,
+	TEST_EDK2_STATUS_CODE_TYPE,
+	TEST_EDK2_BOOT_CODE,
+	TEST_EDK2_INSTANCE,
+};
+
+static rpmi_uint32_t logged_words[] = {
+	TEST_LOG_WORD0,
+	TEST_LOG_WORD1,
+};
+
+static rpmi_uint32_t edk2_progress_words[] = {
+	TEST_EDK2_STATUS_CODE_TYPE,
+	TEST_EDK2_PROGRESS_CODE,
+	TEST_EDK2_INSTANCE,
+};
+
+static rpmi_uint32_t edk2_boot_words[] = {
+	TEST_EDK2_STATUS_CODE_TYPE,
+	TEST_EDK2_BOOT_CODE,
+	TEST_EDK2_INSTANCE,
+};
+
+static rpmi_uint32_t notsupp_expdata[] = {
+	RPMI_ERR_NOTSUPP,
+};
+
+static rpmi_uint32_t success_expdata[] = {
+	RPMI_SUCCESS,
+};
+
+static rpmi_uint32_t invalid_param_expdata[] = {
+	RPMI_ERR_INVALID_PARAM,
+};
+
+static rpmi_uint32_t denied_expdata[] = {
+	RPMI_ERR_DENIED,
+};
+
+static const struct test_logging_expect expect_no_call = {
+	.call_count = 0,
+};
+
+static const struct test_logging_expect expect_log_data = {
+	.call_count = 1,
+	.log_type = TEST_LOG_TYPE,
+	.num_words = ARRAY_SIZE(logged_words),
+	.words = logged_words,
+};
+
+static const struct test_logging_expect expect_edk2_progress = {
+	.call_count = 1,
+	.log_type = TEST_EDK2_STATUS_LOG_TYPE,
+	.num_words = ARRAY_SIZE(edk2_progress_words),
+	.words = edk2_progress_words,
+};
+
+static const struct test_logging_expect expect_edk2_boot = {
+	.call_count = 1,
+	.log_type = TEST_EDK2_STATUS_LOG_TYPE,
+	.num_words = ARRAY_SIZE(edk2_boot_words),
+	.words = edk2_boot_words,
+};
+
+static const struct test_logging_expect expect_log_data_zero_words = {
+	.call_count = 1,
+	.log_type = TEST_LOG_TYPE,
+	.num_words = 0,
+};
+
+static const struct test_logging_expect expect_denied = {
+	.call_count = 1,
+	.log_type = TEST_LOG_TYPE_DENIED,
+	.num_words = 0,
+};
+
+static const struct test_logging_expect expect_denied_words = {
+	.call_count = 1,
+	.log_type = TEST_LOG_TYPE_DENIED,
+	.num_words = ARRAY_SIZE(logged_words),
+	.words = logged_words,
+};
+
+static enum rpmi_error test_logging_log_data(void *priv,
+					     rpmi_uint32_t log_type,
+					     rpmi_uint32_t num_words,
+					     const rpmi_uint32_t *words)
+{
+	struct test_logging_capture *capture = priv;
+	rpmi_uint32_t i;
+
+	if (!capture || num_words > TEST_LOG_MAX_WORDS)
+		return RPMI_ERR_INVALID_PARAM;
+
+	capture->call_count++;
+	capture->log_type = log_type;
+	capture->num_words = num_words;
+	rpmi_env_memset(capture->words, 0, sizeof(capture->words));
+
+	for (i = 0; i < num_words; i++) {
+		if (!words)
+			return RPMI_ERR_INVALID_PARAM;
+		capture->words[i] = words[i];
+	}
+
+	if (log_type == TEST_LOG_TYPE_DENIED)
+		return RPMI_ERR_DENIED;
+
+	return RPMI_SUCCESS;
+}
+
+static struct rpmi_logging_platform_ops test_logging_ops = {
+	.log_data = test_logging_log_data,
+};
+
+static int test_logging_test_init(struct rpmi_test_scenario *scene,
+				  struct rpmi_test *test)
+{
+	rpmi_env_memset(&test_logging_capture, 0, sizeof(test_logging_capture));
+	return 0;
+}
+
+static int test_logging_verify_platform(struct rpmi_test_scenario *scene,
+					struct rpmi_test *test,
+					struct rpmi_message *msg)
+{
+	const struct test_logging_expect *expect = test->priv;
+	rpmi_uint32_t i;
+	int failed = 0;
+
+	if (!expect)
+		return 0;
+
+	if (test_logging_capture.call_count != expect->call_count) {
+		printf("%s: log callback count mismatch: expected: %u, got: %u\n",
+		       test->name, expect->call_count,
+		       test_logging_capture.call_count);
+		failed = 1;
+	}
+
+	if (!expect->call_count)
+		return failed;
+
+	if (test_logging_capture.log_type != expect->log_type) {
+		printf("%s: log type mismatch: expected: %u, got: %u\n",
+		       test->name, expect->log_type,
+		       test_logging_capture.log_type);
+		failed = 1;
+	}
+
+	if (test_logging_capture.num_words != expect->num_words) {
+		printf("%s: log word count mismatch: expected: %u, got: %u\n",
+		       test->name, expect->num_words,
+		       test_logging_capture.num_words);
+		failed = 1;
+	}
+
+	for (i = 0; i < expect->num_words; i++) {
+		if (test_logging_capture.words[i] == expect->words[i])
+			continue;
+
+		printf("%s: log word %u mismatch: expected: 0x%x, got: 0x%x\n",
+		       test->name, i, expect->words[i],
+		       test_logging_capture.words[i]);
+		failed = 1;
+	}
+
+	return failed;
+}
+
+static int test_logging_group_allows_s_mode(void)
+{
+	struct rpmi_service_group *grp;
+	int ret = 0;
+
+	grp = rpmi_service_group_logging_create(&test_logging_ops,
+						&test_logging_capture);
+	if (!grp) {
+		printf("failed to create rpmi logging service group\n");
+		return 1;
+	}
+
+	if (!(grp->privilege_level_bitmap & RPMI_PRIVILEGE_S_MODE_MASK)) {
+		printf("logging service group does not allow S-mode access\n");
+		ret = 1;
+	}
+
+	rpmi_service_group_logging_destroy(grp);
+	return ret;
+}
+
+static int test_logging_big_endian_log_data(void)
+{
+	struct rpmi_test test = {
+		.name = "LOG DATA TEST (big-endian request)",
+		.priv = (void *)&expect_denied_words,
+	};
+	struct rpmi_transport trans = { .is_be = true };
+	struct rpmi_service_group *grp;
+	struct rpmi_service *service;
+	rpmi_uint32_t req[ARRAY_SIZE(log_data_denied_words_reqdata)];
+	rpmi_uint32_t resp[ARRAY_SIZE(denied_expdata)];
+	rpmi_uint16_t resp_len = 0;
+	enum rpmi_error rc;
+	rpmi_uint32_t i;
+	int failed = 0;
+
+	grp = rpmi_service_group_logging_create(&test_logging_ops,
+						&test_logging_capture);
+	if (!grp) {
+		printf("failed to create rpmi logging service group\n");
+		return 1;
+	}
+
+	rpmi_env_memset(&test_logging_capture, 0, sizeof(test_logging_capture));
+	for (i = 0; i < ARRAY_SIZE(req); i++)
+		req[i] = rpmi_to_xe32(trans.is_be,
+					 log_data_denied_words_reqdata[i]);
+
+	service = &grp->services[RPMI_LOGGING_SRV_LOG_DATA];
+	rpmi_env_lock(grp->lock);
+	rc = service->process_a2p_request(grp, service, &trans, sizeof(req),
+					  (const rpmi_uint8_t *)req, &resp_len,
+					  (rpmi_uint8_t *)resp);
+	rpmi_env_unlock(grp->lock);
+	if (rc) {
+		printf("%s: service callback failed: %d\n", test.name, rc);
+		failed = 1;
+	}
+
+	if (resp_len != sizeof(denied_expdata)) {
+		printf("%s: response length mismatch: expected: %zu, got: %u\n",
+		       test.name, sizeof(denied_expdata), resp_len);
+		failed = 1;
+	} else if (resp[0] != rpmi_to_xe32(trans.is_be, denied_expdata[0])) {
+		printf("%s: response status mismatch: expected: 0x%x, got: 0x%x\n",
+		       test.name, rpmi_to_xe32(trans.is_be, denied_expdata[0]),
+		       resp[0]);
+		failed = 1;
+	}
+
+	failed += test_logging_verify_platform(NULL, &test, NULL);
+	printf("TEST: %-50s \t : %s!\n", test.name,
+	       failed ? "Failed" : "Succeeded");
+
+	rpmi_service_group_logging_destroy(grp);
+	return failed;
+}
+
+static int test_logging_scenario_cleanup(struct rpmi_test_scenario *scene)
+{
+	struct test_logging_scenario_config *config = scene->priv;
+
+	if (scene->cntx && config && config->grp) {
+		rpmi_context_remove_group(scene->cntx, config->grp);
+		rpmi_service_group_logging_destroy(config->grp);
+		config->grp = NULL;
+	}
+
+	if (scene->cntx) {
+		rpmi_context_destroy(scene->cntx);
+		scene->cntx = NULL;
+	}
+
+	return test_scenario_default_cleanup(scene);
+}
+
+static int test_logging_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct test_logging_scenario_config *config;
+	struct rpmi_service_group *grp;
+	enum rpmi_privilege_level privilege_level;
+	int ret;
+
+	if (!scene)
+		return RPMI_ERR_INVALID_PARAM;
+
+	config = scene->priv;
+	if (!config)
+		return RPMI_ERR_INVALID_PARAM;
+
+	if (scene->shm || scene->shmem || scene->xport || scene->cntx)
+		return RPMI_ERR_ALREADY;
+
+	scene->shm = rpmi_env_zalloc(scene->shm_size);
+	if (!scene->shm)
+		return RPMI_ERR_FAILED;
+
+	scene->shmem = rpmi_shmem_create("test_shmem",
+					 (unsigned long)scene->shm,
+					 scene->shm_size,
+					 &rpmi_shmem_simple_ops, NULL);
+	if (!scene->shmem) {
+		printf("%s: failed to create test rpmi_shmem\n ", __func__);
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->xport = rpmi_transport_shmem_create("test_transport",
+						   scene->slot_size,
+						   ((scene->shm_size * 3) / 4) / 2,
+						   ((scene->shm_size * 1) / 4) / 2,
+						   scene->shmem);
+	if (!scene->xport) {
+		printf("%s: failed to create test rpmi_transport\n ", __func__);
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+	scene->xport->is_be = config->is_be;
+
+	privilege_level = config->privilege_level;
+	scene->cntx = rpmi_context_create("test_context", scene->xport,
+					  scene->max_num_groups,
+					  privilege_level,
+					  scene->base.plat_info_len,
+					  scene->base.plat_info);
+	if (!scene->cntx) {
+		printf("%s: failed to create test rpmi_context\n ", __func__);
+		ret = RPMI_ERR_FAILED;
+		goto fail_cleanup;
+	}
+
+	grp = rpmi_service_group_logging_create(&test_logging_ops,
+						&test_logging_capture);
+	if (!grp) {
+		printf("failed to create rpmi logging service group\n");
+		ret = RPMI_ERR_FAILED;
+		goto fail_cleanup;
+	}
+
+	ret = rpmi_context_add_group(scene->cntx, grp);
+	if (ret) {
+		printf("failed to add rpmi logging service group\n");
+		rpmi_service_group_logging_destroy(grp);
+		goto fail_cleanup;
+	}
+	config->grp = grp;
+	scene->token_sequence = 0;
+
+	return 0;
+
+fail_cleanup:
+	test_logging_scenario_cleanup(scene);
+	return ret;
+}
+
+static struct test_logging_scenario_config logging_m_mode_config = {
+	.privilege_level = RPMI_PRIVILEGE_M_MODE,
+};
+
+static struct rpmi_test_scenario scenario_logging_default = {
+	.name = "Logging Service Group",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &logging_m_mode_config,
+
+	.init = test_logging_scenario_init,
+	.cleanup = test_logging_scenario_cleanup,
+
+	.num_tests = 10,
+	.tests = {
+		{
+			.name = "ENABLE NOTIFICATION TEST (notifications not supported)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_ENABLE_NOTIFICATION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = enable_notif_reqdata,
+				.request_data_len = sizeof(enable_notif_reqdata),
+				.expected_data = notsupp_expdata,
+				.expected_data_len = sizeof(notsupp_expdata),
+			},
+			.priv = (void *)&expect_no_call,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = log_data_reqdata,
+				.request_data_len = sizeof(log_data_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.priv = (void *)&expect_log_data,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (short request)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = log_data_short_reqdata,
+				.request_data_len = sizeof(log_data_short_reqdata),
+				.expected_data = notsupp_expdata,
+				.expected_data_len = sizeof(notsupp_expdata),
+			},
+			.priv = (void *)&expect_no_call,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (zero words)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = log_data_zero_words_reqdata,
+				.request_data_len = sizeof(log_data_zero_words_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.priv = (void *)&expect_log_data_zero_words,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (captured EDK2 progress code)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = edk2_progress_reqdata,
+				.request_data_len = sizeof(edk2_progress_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.priv = (void *)&expect_edk2_progress,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (captured EDK2 boot code)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = edk2_boot_reqdata,
+				.request_data_len = sizeof(edk2_boot_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.priv = (void *)&expect_edk2_boot,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (NUM_WORDS mismatch)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = log_data_bad_count_reqdata,
+				.request_data_len = sizeof(log_data_bad_count_reqdata),
+				.expected_data = invalid_param_expdata,
+				.expected_data_len = sizeof(invalid_param_expdata),
+			},
+			.priv = (void *)&expect_no_call,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (unaligned request)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = log_data_unaligned_reqdata,
+				.request_data_len = sizeof(log_data_unaligned_reqdata),
+				.expected_data = invalid_param_expdata,
+				.expected_data_len = sizeof(invalid_param_expdata),
+			},
+			.priv = (void *)&expect_no_call,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (platform error)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = log_data_denied_reqdata,
+				.request_data_len = sizeof(log_data_denied_reqdata),
+				.expected_data = denied_expdata,
+				.expected_data_len = sizeof(denied_expdata),
+			},
+			.priv = (void *)&expect_denied,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+		{
+			.name = "LOG DATA TEST (posted request)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_POSTED_REQUEST,
+				.request_data = log_data_reqdata,
+				.request_data_len = sizeof(log_data_reqdata),
+			},
+			.priv = (void *)&expect_log_data,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+	},
+};
+
+static struct test_logging_scenario_config logging_s_mode_config = {
+	.privilege_level = RPMI_PRIVILEGE_S_MODE,
+};
+
+static struct rpmi_test_scenario scenario_logging_s_mode = {
+	.name = "Logging Service Group (S-mode)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &logging_s_mode_config,
+
+	.init = test_logging_scenario_init,
+	.cleanup = test_logging_scenario_cleanup,
+
+	.num_tests = 1,
+	.tests = {
+		{
+			.name = "LOG DATA TEST (S-mode request)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_LOGGING,
+				.service_id = RPMI_LOGGING_SRV_LOG_DATA,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = edk2_boot_reqdata,
+				.request_data_len = sizeof(edk2_boot_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.priv = (void *)&expect_edk2_boot,
+			.init = test_logging_test_init,
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = test_logging_verify_platform,
+		},
+	},
+};
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	printf("Test Logging Service Group\n");
+
+	ret = test_logging_group_allows_s_mode();
+	if (ret)
+		return ret;
+
+	ret = test_scenario_execute(&scenario_logging_default);
+	ret |= test_scenario_execute(&scenario_logging_s_mode);
+	ret |= test_logging_big_endian_log_data();
+
+	return ret;
+}


### PR DESCRIPTION
Summary:
- align LOGGING service 0x02 with LOG_DATA request format
- allow LOGGING from S-mode and keep notifications unsupported
- add test_srvgrp_logging coverage

Testing:
- make O=/tmp/librpmi-build-final-cross LIBRPMI_TEST=y
- make O=/tmp/librpmi-build-final-host LIBRPMI_TEST=y CROSS_COMPILE=
- /tmp/librpmi-build-final-host/test/test_srvgrp_logging.elf