### PR TITLE
lib: cppc: add autonomous (CPPC2) mode support

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -1498,17 +1498,26 @@ struct rpmi_cppc_platform_ops {
 					rpmi_uint32_t hart_index,
 					rpmi_uint64_t val);
 	/**
-	 * cppc update performance level for a hart
+	 * cppc update performance level for a hart (passive/normal mode)
 	 */
 	enum rpmi_error (*cppc_update_perf)(void *priv,
 					    rpmi_uint32_t hart_index,
 					    rpmi_uint32_t desired_perf);
+
 	/**
 	 * cppc get current frequency in hertz for a hart
 	 */
 	enum rpmi_error (*cppc_get_current_freq)(void *priv,
 						 rpmi_uint32_t hart_index,
 						 rpmi_uint64_t *current_freq_hz);
+
+	/**
+	 * cppc update performance bounds for a hart (autonomous mode)
+	 */
+	enum rpmi_error (*cppc_update_perf_auto)(void *priv,
+						 rpmi_uint32_t hart_index,
+						 rpmi_uint32_t min_perf,
+						 rpmi_uint32_t max_perf);
 };
 
 /**

--- a/lib/rpmi_service_group_cppc.c
+++ b/lib/rpmi_service_group_cppc.c
@@ -665,16 +665,10 @@ rpmi_cppc_sg_get_fast_channel_region(struct rpmi_service_group *group,
 	resp[6] = 0;
 	/* doorbell addr high */
 	resp[7] = 0;
-	/* doorbell set mask low */
+	/* doorbell write value */
 	resp[8] = 0;
-	/* doorbell set mask high */
-	resp[9] = 0;
-	/* doorbell preserve mask low */
-	resp[10] = 0;
-	/* doorbell preserve mask high */
-	resp[11] = 0;
 
-	resp_dlen = 12 * sizeof(*resp);
+	resp_dlen = 9 * sizeof(*resp);
 
 done:
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)status);

--- a/lib/rpmi_service_group_cppc.c
+++ b/lib/rpmi_service_group_cppc.c
@@ -58,6 +58,9 @@ struct rpmi_cppc_group {
 	/** CPPC mode of operation */
 	enum rpmi_cppc_mode cppc_mode;
 
+	/** current value of AutonomousSelectionEnable register */
+	rpmi_uint32_t autonomous_selection_enable;
+
 	/**
 	 * hsm context representing all harts managed
 	 * by CPPC service group
@@ -114,7 +117,7 @@ __cppc_hart_fc_perf_feedback_offset(struct rpmi_cppc_fastchan *fastchan_ctx,
 }
 
 /**
- * Get the desired_perf value from fastchannel of a hart
+ * Get the desired_perf value from fastchannel of a hart (passive mode)
  */
 static inline rpmi_uint32_t
 __cppc_get_fc_desired_perf(struct rpmi_cppc_group *cppcgrp,
@@ -125,6 +128,49 @@ __cppc_get_fc_desired_perf(struct rpmi_cppc_group *cppcgrp,
 	rpmi_uint64_t offset;
 
 	offset = __cppc_hart_fc_perf_request_offset(cppcgrp->fastchan_ctx, hart_index);
+
+	rc = rpmi_shmem_read(cppcgrp->fastchan_ctx->shmem, offset, &val,
+			     sizeof(rpmi_uint32_t));
+	if (rc)
+		return 0;
+
+	return val;
+}
+
+/**
+ * Get the min_perf value from fastchannel of a hart (autonomous mode)
+ */
+static inline rpmi_uint32_t
+__cppc_get_fc_min_perf(struct rpmi_cppc_group *cppcgrp, rpmi_uint32_t hart_index)
+{
+	int rc;
+	rpmi_uint32_t val;
+	rpmi_uint64_t offset;
+
+	/* active.min_perf is the first u32 of the fastchannel entry */
+	offset = __cppc_hart_fc_perf_request_offset(cppcgrp->fastchan_ctx, hart_index);
+
+	rc = rpmi_shmem_read(cppcgrp->fastchan_ctx->shmem, offset, &val,
+			     sizeof(rpmi_uint32_t));
+	if (rc)
+		return 0;
+
+	return val;
+}
+
+/**
+ * Get the max_perf value from fastchannel of a hart (autonomous mode)
+ */
+static inline rpmi_uint32_t
+__cppc_get_fc_max_perf(struct rpmi_cppc_group *cppcgrp, rpmi_uint32_t hart_index)
+{
+	int rc;
+	rpmi_uint32_t val;
+	rpmi_uint64_t offset;
+
+	/* active.max_perf is the second u32 of the fastchannel entry */
+	offset = __cppc_hart_fc_perf_request_offset(cppcgrp->fastchan_ctx, hart_index)
+		 + sizeof(rpmi_uint32_t);
 
 	rc = rpmi_shmem_read(cppcgrp->fastchan_ctx->shmem, offset, &val,
 			     sizeof(rpmi_uint32_t));
@@ -184,17 +230,36 @@ static enum rpmi_error __rpmi_cppc_probe_reg(struct rpmi_cppc_group *cppcgrp,
 		status = RPMI_SUCCESS;
 		len = BITS(sizeof(rpmi_uint64_t));
 		break;
-	/** Not implemented registers (will be in future) */
-	case RPMI_CPPC_MAX_PERF:
-	case RPMI_CPPC_MIN_PERF:
+	/* Available in both modes */
 	case RPMI_CPPC_GUARANTEED_PERF:
-	case RPMI_CPPC_TIME_WINDOW:
-	case RPMI_CPPC_PERF_REDUCTION_TOLERANCE:
-	case RPMI_CPPC_AUTONOMOUS_SELECTION_ENABLE:
 	case RPMI_CPPC_CPPC_ENABLE:
+		status = RPMI_SUCCESS;
+		len = BITS(sizeof(rpmi_uint32_t));
+		break;
 	case RPMI_CPPC_COUNTER_WRAPAROUND_TIME:
+		status = RPMI_SUCCESS;
+		len = BITS(sizeof(rpmi_uint64_t));
+		break;
+	/* Available in both modes */
+	case RPMI_CPPC_MIN_PERF:
+	case RPMI_CPPC_MAX_PERF:
+		status = RPMI_SUCCESS;
+		len = BITS(sizeof(rpmi_uint32_t));
+		break;
+	/* Autonomous (CPPC2) mode only */
+	case RPMI_CPPC_PERF_REDUCTION_TOLERANCE:
+	case RPMI_CPPC_TIME_WINDOW:
+	case RPMI_CPPC_AUTONOMOUS_SELECTION_ENABLE:
 	case RPMI_CPPC_AUTONOMOUS_ACTIVITY_WINDOW:
 	case RPMI_CPPC_ENERGY_PERF_PREFERENCE:
+		if (cppcgrp->cppc_mode != RPMI_CPPC_AUTO_MODE) {
+			status = RPMI_ERR_NOTSUPP;
+			len = 0;
+			break;
+		}
+		status = RPMI_SUCCESS;
+		len = BITS(sizeof(rpmi_uint32_t));
+		break;
 	default:
 		DPRINTF("%s: CPPC reg-%u not implemented\n", __func__, reg_id);
 		status = RPMI_ERR_NOTSUPP;
@@ -264,6 +329,49 @@ static enum rpmi_error __rpmi_cppc_read_reg(struct rpmi_cppc_group *cppcgrp,
 	case RPMI_CPPC_TRANSITION_LATENCY:
 		val = cppcgrp->regs->transition_latency;
 		break;
+	/* Available in both modes, static from regs struct */
+	case RPMI_CPPC_GUARANTEED_PERF:
+		val = cppcgrp->regs->guaranteed_perf;
+		break;
+	case RPMI_CPPC_COUNTER_WRAPAROUND_TIME:
+		val = cppcgrp->regs->counter_wraparound_time;
+		break;
+	/* Available in both modes, delegated to platform */
+	case RPMI_CPPC_CPPC_ENABLE:
+		status = cppcgrp->ops->cppc_get_reg(cppcgrp->ops_priv,
+						    RPMI_CPPC_CPPC_ENABLE,
+						    hart_index, &val);
+		break;
+	/* Available in both modes: fastchannel in autonomous mode if present */
+	case RPMI_CPPC_MIN_PERF:
+		if (cppcgrp->cppc_mode == RPMI_CPPC_AUTO_MODE &&
+		    cppcgrp->autonomous_selection_enable &&
+		    cppcgrp->fastchan_ctx)
+			val = __cppc_get_fc_min_perf(cppcgrp, hart_index);
+		else
+			status = cppcgrp->ops->cppc_get_reg(cppcgrp->ops_priv,
+							    RPMI_CPPC_MIN_PERF,
+							    hart_index, &val);
+		break;
+	case RPMI_CPPC_MAX_PERF:
+		if (cppcgrp->cppc_mode == RPMI_CPPC_AUTO_MODE &&
+		    cppcgrp->autonomous_selection_enable &&
+		    cppcgrp->fastchan_ctx)
+			val = __cppc_get_fc_max_perf(cppcgrp, hart_index);
+		else
+			status = cppcgrp->ops->cppc_get_reg(cppcgrp->ops_priv,
+							    RPMI_CPPC_MAX_PERF,
+							    hart_index, &val);
+		break;
+	/* Autonomous mode only, delegated to platform */
+	case RPMI_CPPC_PERF_REDUCTION_TOLERANCE:
+	case RPMI_CPPC_TIME_WINDOW:
+	case RPMI_CPPC_AUTONOMOUS_SELECTION_ENABLE:
+	case RPMI_CPPC_AUTONOMOUS_ACTIVITY_WINDOW:
+	case RPMI_CPPC_ENERGY_PERF_PREFERENCE:
+		status = cppcgrp->ops->cppc_get_reg(cppcgrp->ops_priv,
+						    reg_id, hart_index, &val);
+		break;
 	default:
 		/* No read permission */
 		status = RPMI_ERR_DENIED;
@@ -296,6 +404,32 @@ static enum rpmi_error __rpmi_cppc_write_reg(struct rpmi_cppc_group *cppcgrp,
 						    hart_index,
 						    reg_val);
 		break;
+	/* Available in both modes, delegated to platform */
+	case RPMI_CPPC_MIN_PERF:
+	case RPMI_CPPC_MAX_PERF:
+		if ((rpmi_uint32_t)reg_val < cppcgrp->regs->lowest_perf ||
+		    (rpmi_uint32_t)reg_val > cppcgrp->regs->highest_perf) {
+			status = RPMI_ERR_INVALID_PARAM;
+			break;
+		}
+		status = cppcgrp->ops->cppc_set_reg(cppcgrp->ops_priv,
+						    reg_id, hart_index, reg_val);
+		break;
+	/* Writable in both modes via message interface */
+	case RPMI_CPPC_CPPC_ENABLE:
+	/* Autonomous mode only, writable via message interface */
+	case RPMI_CPPC_AUTONOMOUS_SELECTION_ENABLE:
+		if (reg_id == RPMI_CPPC_AUTONOMOUS_SELECTION_ENABLE)
+			cppcgrp->autonomous_selection_enable =
+				(rpmi_uint32_t)reg_val;
+		fallthrough;
+	case RPMI_CPPC_AUTONOMOUS_ACTIVITY_WINDOW:
+	case RPMI_CPPC_ENERGY_PERF_PREFERENCE:
+	case RPMI_CPPC_TIME_WINDOW:
+	case RPMI_CPPC_PERF_REDUCTION_TOLERANCE:
+		status = cppcgrp->ops->cppc_set_reg(cppcgrp->ops_priv,
+						    reg_id, hart_index, reg_val);
+		break;
 	case RPMI_CPPC_DELIVERED_PERF_COUNTER:
 	case RPMI_CPPC_REFERENCE_PERF_COUNTER:
 	case RPMI_CPPC_HIGHEST_PERF:
@@ -303,6 +437,8 @@ static enum rpmi_error __rpmi_cppc_write_reg(struct rpmi_cppc_group *cppcgrp,
 	case RPMI_CPPC_LOWEST_NON_LINEAR_PERF:
 	case RPMI_CPPC_LOWEST_PERF:
 	case RPMI_CPPC_REFERENCE_PERF:
+	case RPMI_CPPC_GUARANTEED_PERF:
+	case RPMI_CPPC_COUNTER_WRAPAROUND_TIME:
 	case RPMI_CPPC_PERF_LIMITED:
 	case RPMI_CPPC_LOWEST_FREQ:
 	case RPMI_CPPC_NOMINAL_FREQ:
@@ -512,8 +648,8 @@ rpmi_cppc_sg_get_fast_channel_region(struct rpmi_service_group *group,
 	fastchan_region_base = rpmi_shmem_base(cppcgrp->fastchan_ctx->shmem);
 	fastchan_region_size = rpmi_shmem_size(cppcgrp->fastchan_ctx->shmem);
 
-	/* No doorbell, and mode is passive */
-	flags = 0;
+	/* FLAGS[4:3]: 0b00 = normal/passive, 0b01 = autonomous. No doorbell. */
+	flags = (cppcgrp->cppc_mode == RPMI_CPPC_AUTO_MODE) ? (0x01U << 3) : 0;
 
 	status = RPMI_SUCCESS;
 	resp[1] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)flags);
@@ -680,34 +816,55 @@ static struct rpmi_service rpmi_cppc_services[RPMI_CPPC_SRV_ID_MAX] = {
 
 static enum rpmi_error rpmi_cppc_process_events(struct rpmi_service_group *group)
 {
-
 	enum rpmi_error status = RPMI_SUCCESS;
-	rpmi_uint32_t hart_idx, desired_perf;
-	rpmi_uint64_t current_freq;
+	rpmi_uint32_t hart_idx, desired_perf, min_perf, max_perf;
+	rpmi_uint64_t current_freq = 0;
 	union rpmi_cppc_perf_request_fastchan *hart_perf_request;
 	struct rpmi_cppc_group *cppcgrp = group->priv;
 
 	for (hart_idx = 0; hart_idx < cppcgrp->hart_count; hart_idx++) {
 		hart_perf_request = &cppcgrp->fastchan_ctx->hart_perf_request[hart_idx];
-		desired_perf = __cppc_get_fc_desired_perf(cppcgrp, hart_idx);
 
-		if (hart_perf_request->passive.desired_perf != desired_perf) {
-			hart_perf_request->passive.desired_perf = desired_perf;
-			status = cppcgrp->ops->cppc_update_perf(cppcgrp->ops_priv,
-					   hart_idx,
-					   desired_perf);
-			/**
-			 * Dont throw error at this point and
-			 * directly get the current frequency for hart
-			 * for which the cppc_update_perf is called. If
-			 * the performance level update failed, it will
-			 * be reflected into the performance feedback
-			 **/
-			cppcgrp->ops->cppc_get_current_freq(cppcgrp->ops_priv,
-							    hart_idx,
-							    &current_freq);
-			status = __cppc_set_fc_current_freq(cppcgrp, hart_idx,
-							    current_freq);
+		if (cppcgrp->cppc_mode == RPMI_CPPC_PASSIVE_MODE) {
+			desired_perf = __cppc_get_fc_desired_perf(cppcgrp, hart_idx);
+
+			if (hart_perf_request->passive.desired_perf != desired_perf) {
+				hart_perf_request->passive.desired_perf = desired_perf;
+				status = cppcgrp->ops->cppc_update_perf(cppcgrp->ops_priv,
+								hart_idx, desired_perf);
+				/*
+				 * Don't bail on update error — get the current
+				 * frequency anyway so the feedback fastchannel
+				 * reflects the actual state.
+				 */
+				current_freq = 0;
+				if (!cppcgrp->ops->cppc_get_current_freq(cppcgrp->ops_priv,
+									 hart_idx,
+									 &current_freq))
+					status = __cppc_set_fc_current_freq(cppcgrp,
+									    hart_idx,
+									    current_freq);
+			}
+		} else if (cppcgrp->autonomous_selection_enable) {
+			min_perf = __cppc_get_fc_min_perf(cppcgrp, hart_idx);
+			max_perf = __cppc_get_fc_max_perf(cppcgrp, hart_idx);
+
+			if (hart_perf_request->active.min_perf != min_perf ||
+			    hart_perf_request->active.max_perf != max_perf) {
+				hart_perf_request->active.min_perf = min_perf;
+				hart_perf_request->active.max_perf = max_perf;
+				if (cppcgrp->ops->cppc_update_perf_auto)
+					status = cppcgrp->ops->cppc_update_perf_auto(cppcgrp->ops_priv,
+									hart_idx,
+									min_perf, max_perf);
+				current_freq = 0;
+				if (!cppcgrp->ops->cppc_get_current_freq(cppcgrp->ops_priv,
+									 hart_idx,
+									 &current_freq))
+					status = __cppc_set_fc_current_freq(cppcgrp,
+									    hart_idx,
+									    current_freq);
+			}
 		}
 	}
 
@@ -871,8 +1028,8 @@ rpmi_service_group_cppc_create(struct rpmi_hsm *hsm,
 		return NULL;
 	}
 
-	if (mode != RPMI_CPPC_PASSIVE_MODE) {
-		DPRINTF("%s: cppc mode not supported\n", __func__);
+	if (mode != RPMI_CPPC_PASSIVE_MODE && mode != RPMI_CPPC_AUTO_MODE) {
+		DPRINTF("%s: unknown cppc mode\n", __func__);
 		return NULL;
 	}
 
@@ -918,6 +1075,9 @@ rpmi_service_group_cppc_create(struct rpmi_hsm *hsm,
 	 * conversion is done by platform only.
 	 */
 	cppcgrp->regs = cppc_regs;
+	cppcgrp->cppc_mode = mode;
+	cppcgrp->autonomous_selection_enable =
+		cppc_regs->autonomous_selection_enable;
 	cppcgrp->fastchan_ctx = cppc_fastchan_ctx;
 	cppcgrp->hart_count = hart_count;
 	cppcgrp->hsm = hsm;

--- a/lib/rpmi_service_group_cppc.c
+++ b/lib/rpmi_service_group_cppc.c
@@ -466,10 +466,10 @@ rpmi_cppc_sg_probe_reg(struct rpmi_service_group *group,
 	struct rpmi_cppc_group *cppcgrp = group->priv;
 	rpmi_uint32_t *resp = (void *)response_data;
 
-	hart_id = rpmi_to_xe32(trans->is_be,
-			((const rpmi_uint32_t *)request_data)[0]);
 	cppc_reg_id = rpmi_to_xe32(trans->is_be,
-			    ((const rpmi_uint32_t *)request_data)[1]);
+			    ((const rpmi_uint32_t *)request_data)[0]);
+	hart_id = rpmi_to_xe32(trans->is_be,
+			       ((const rpmi_uint32_t *)request_data)[1]);
 
 	/** valid cppc register */
 	if (!__cppc_reg_valid(cppc_reg_id)) {
@@ -514,10 +514,10 @@ rpmi_cppc_sg_read_reg(struct rpmi_service_group *group,
 	struct rpmi_cppc_group *cppcgrp = group->priv;
 	rpmi_uint32_t *resp = (void *)response_data;
 
-	hart_id = rpmi_to_xe32(trans->is_be,
-			((const rpmi_uint32_t *)request_data)[0]);
 	cppc_reg_id = rpmi_to_xe32(trans->is_be,
-			    ((const rpmi_uint32_t *)request_data)[1]);
+			    ((const rpmi_uint32_t *)request_data)[0]);
+	hart_id = rpmi_to_xe32(trans->is_be,
+			       ((const rpmi_uint32_t *)request_data)[1]);
 
 	data_lo = 0;
 	data_hi = 0;
@@ -585,10 +585,10 @@ rpmi_cppc_sg_write_reg(struct rpmi_service_group *group,
 	struct rpmi_cppc_group *cppcgrp = group->priv;
 	rpmi_uint32_t *resp = (void *)response_data;
 
-	hart_id = rpmi_to_xe32(trans->is_be,
-			((const rpmi_uint32_t *)request_data)[0]);
 	cppc_reg_id = rpmi_to_xe32(trans->is_be,
-			    ((const rpmi_uint32_t *)request_data)[1]);
+			    ((const rpmi_uint32_t *)request_data)[0]);
+	hart_id = rpmi_to_xe32(trans->is_be,
+			       ((const rpmi_uint32_t *)request_data)[1]);
 
 	data_lo = rpmi_to_xe32(trans->is_be,
 			((const rpmi_uint32_t *)request_data)[2]);

--- a/test/test_srvgrp_cppc.c
+++ b/test/test_srvgrp_cppc.c
@@ -60,8 +60,8 @@ static rpmi_uint32_t enable_notif_expdata[] = {
 };
 
 static rpmi_uint32_t probe_highest_reqdata[] = {
-	TEST_HART_ID,
 	RPMI_CPPC_HIGHEST_PERF,
+	TEST_HART_ID,
 };
 
 static rpmi_uint32_t probe_32bit_expdata[] = {
@@ -70,8 +70,8 @@ static rpmi_uint32_t probe_32bit_expdata[] = {
 };
 
 static rpmi_uint32_t probe_not_supp_reqdata[] = {
-	TEST_HART_ID,
 	RPMI_CPPC_ENERGY_PERF_PREFERENCE,
+	TEST_HART_ID,
 };
 
 static rpmi_uint32_t probe_not_supp_expdata[] = {
@@ -80,8 +80,8 @@ static rpmi_uint32_t probe_not_supp_expdata[] = {
 };
 
 static rpmi_uint32_t probe_invalid_reg_reqdata[] = {
-	TEST_HART_ID,
 	RPMI_CPPC_NON_ACPI_REG_MAX_IDX,
+	TEST_HART_ID,
 };
 
 static rpmi_uint32_t invalid_param_expdata[] = {
@@ -89,8 +89,8 @@ static rpmi_uint32_t invalid_param_expdata[] = {
 };
 
 static rpmi_uint32_t read_highest_reqdata[] = {
-	TEST_HART_ID,
 	RPMI_CPPC_HIGHEST_PERF,
+	TEST_HART_ID,
 };
 
 static rpmi_uint32_t read_highest_expdata[] = {
@@ -100,8 +100,8 @@ static rpmi_uint32_t read_highest_expdata[] = {
 };
 
 static rpmi_uint32_t read_counter_reqdata[] = {
-	TEST_HART_ID,
 	RPMI_CPPC_REFERENCE_PERF_COUNTER,
+	TEST_HART_ID,
 };
 
 static rpmi_uint32_t read_counter_expdata[] = {
@@ -111,13 +111,13 @@ static rpmi_uint32_t read_counter_expdata[] = {
 };
 
 static rpmi_uint32_t read_invalid_hart_reqdata[] = {
-	TEST_HART_ID_INVALID,
 	RPMI_CPPC_HIGHEST_PERF,
+	TEST_HART_ID_INVALID,
 };
 
 static rpmi_uint32_t write_readonly_reqdata[] = {
-	TEST_HART_ID,
 	RPMI_CPPC_HIGHEST_PERF,
+	TEST_HART_ID,
 	1,
 	0,
 };
@@ -540,12 +540,12 @@ static struct rpmi_cppc_regs test_cppc_auto_regs = {
 
 /* PROBE: autonomous-mode-only register → SUCCESS + 32 */
 static rpmi_uint32_t probe_min_perf_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_MIN_PERF,
+	RPMI_CPPC_MIN_PERF, TEST_HART_ID,
 };
 
 /* PROBE: both-modes register (64-bit) → SUCCESS + 64 */
 static rpmi_uint32_t probe_wraparound_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_COUNTER_WRAPAROUND_TIME,
+	RPMI_CPPC_COUNTER_WRAPAROUND_TIME, TEST_HART_ID,
 };
 
 static rpmi_uint32_t probe_64bit_expdata[] = {
@@ -554,17 +554,17 @@ static rpmi_uint32_t probe_64bit_expdata[] = {
 
 /* PROBE: guaranteed_perf (both modes, 32-bit) */
 static rpmi_uint32_t probe_guaranteed_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_GUARANTEED_PERF,
+	RPMI_CPPC_GUARANTEED_PERF, TEST_HART_ID,
 };
 
 /* PROBE: energy_perf_preference (auto only) */
 static rpmi_uint32_t probe_energy_pref_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_ENERGY_PERF_PREFERENCE,
+	RPMI_CPPC_ENERGY_PERF_PREFERENCE, TEST_HART_ID,
 };
 
 /* READ: guaranteed_perf from regs struct */
 static rpmi_uint32_t read_guaranteed_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_GUARANTEED_PERF,
+	RPMI_CPPC_GUARANTEED_PERF, TEST_HART_ID,
 };
 
 static rpmi_uint32_t read_guaranteed_expdata[] = {
@@ -573,7 +573,7 @@ static rpmi_uint32_t read_guaranteed_expdata[] = {
 
 /* READ: counter_wraparound_time (64-bit) from regs struct */
 static rpmi_uint32_t read_wraparound_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_COUNTER_WRAPAROUND_TIME,
+	RPMI_CPPC_COUNTER_WRAPAROUND_TIME, TEST_HART_ID,
 };
 
 static rpmi_uint32_t read_wraparound_expdata[] = {
@@ -582,7 +582,7 @@ static rpmi_uint32_t read_wraparound_expdata[] = {
 
 /* READ: energy_perf_preference via cppc_get_reg */
 static rpmi_uint32_t read_energy_pref_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_ENERGY_PERF_PREFERENCE,
+	RPMI_CPPC_ENERGY_PERF_PREFERENCE, TEST_HART_ID,
 };
 
 static rpmi_uint32_t read_energy_pref_expdata[] = {
@@ -591,7 +591,7 @@ static rpmi_uint32_t read_energy_pref_expdata[] = {
 
 /* WRITE: energy_perf_preference via cppc_set_reg → SUCCESS */
 static rpmi_uint32_t write_energy_pref_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_ENERGY_PERF_PREFERENCE, TEST_CPPC_ENERGY_PREF_VAL, 0,
+	RPMI_CPPC_ENERGY_PERF_PREFERENCE, TEST_HART_ID, TEST_CPPC_ENERGY_PREF_VAL, 0,
 };
 
 static rpmi_uint32_t success_expdata[] = {
@@ -600,7 +600,7 @@ static rpmi_uint32_t success_expdata[] = {
 
 /* WRITE: min_perf while fastchannel is active → DENIED */
 static rpmi_uint32_t write_min_perf_fc_reqdata[] = {
-	TEST_HART_ID, RPMI_CPPC_MIN_PERF, 0x20, 0,
+	RPMI_CPPC_MIN_PERF, TEST_HART_ID, 0x20, 0,
 };
 
 static rpmi_uint16_t init_auto_event_request(struct rpmi_test_scenario *scene,

--- a/test/test_srvgrp_cppc.c
+++ b/test/test_srvgrp_cppc.c
@@ -9,17 +9,28 @@
 #include "test_common.h"
 #include "test_log.h"
 
-#define TEST_HART_ID		0
-#define TEST_HART_ID_INVALID	1
-#define TEST_EVENT_ID		0x0
-#define TEST_REQUEST_STATE_ENABLE	0x1
-#define TEST_CPPC_HIGHEST_PERF	0x64
-#define TEST_CPPC_NOMINAL_PERF	0x50
-#define TEST_CPPC_COUNTER_LO	0x55667788
-#define TEST_CPPC_COUNTER_HI	0x11223344
-#define TEST_CPPC_FASTCHAN_SIZE	64
-#define TEST_CPPC_FASTCHAN_REQ_OFFSET	0
-#define TEST_CPPC_FASTCHAN_FB_OFFSET	RPMI_CPPC_FASTCHAN_SIZE
+#define TEST_HART_ID				0
+#define TEST_HART_ID_INVALID			1
+#define TEST_EVENT_ID				0x0
+#define TEST_REQUEST_STATE_ENABLE		0x1
+#define TEST_CPPC_HIGHEST_PERF			0x64
+#define TEST_CPPC_NOMINAL_PERF			0x50
+#define TEST_CPPC_GUARANTEED_PERF		0x48
+#define TEST_CPPC_COUNTER_LO			0x55667788
+#define TEST_CPPC_COUNTER_HI			0x11223344
+#define TEST_CPPC_WRAPAROUND_LO			0xFFFFFFFF
+#define TEST_CPPC_WRAPAROUND_HI			0x00000001
+#define TEST_CPPC_ENERGY_PREF_VAL		0x80
+#define TEST_CPPC_FASTCHAN_SIZE			64
+#define TEST_CPPC_FASTCHAN_REQ_OFFSET		0
+#define TEST_CPPC_FASTCHAN_FB_OFFSET		RPMI_CPPC_FASTCHAN_SIZE
+/* FLAGS[4:3] = 0b01 for autonomous mode */
+#define TEST_CPPC_AUTO_FLAGS			(0x01U << 3)
+#define TEST_CPPC_AUTO_MIN_PERF			0x20
+#define TEST_CPPC_AUTO_MAX_PERF			0x40
+
+static rpmi_uint32_t test_auto_captured_min_perf;
+static rpmi_uint32_t test_auto_captured_max_perf;
 
 static rpmi_uint8_t test_fastchan_mem[TEST_CPPC_FASTCHAN_SIZE]
 	__aligned(RPMI_CPPC_FASTCHAN_SIZE);
@@ -60,7 +71,7 @@ static rpmi_uint32_t probe_32bit_expdata[] = {
 
 static rpmi_uint32_t probe_not_supp_reqdata[] = {
 	TEST_HART_ID,
-	RPMI_CPPC_MIN_PERF,
+	RPMI_CPPC_ENERGY_PERF_PREFERENCE,
 };
 
 static rpmi_uint32_t probe_not_supp_expdata[] = {
@@ -158,6 +169,11 @@ static enum rpmi_error test_cppc_get_reg(void *priv, rpmi_uint32_t reg_id,
 		return RPMI_SUCCESS;
 	}
 
+	if (reg_id == RPMI_CPPC_ENERGY_PERF_PREFERENCE) {
+		*val = TEST_CPPC_ENERGY_PREF_VAL;
+		return RPMI_SUCCESS;
+	}
+
 	*val = 0;
 	return RPMI_ERR_NOTSUPP;
 }
@@ -176,6 +192,16 @@ static enum rpmi_error test_cppc_update_perf(void *priv,
 	return RPMI_SUCCESS;
 }
 
+static enum rpmi_error test_cppc_update_perf_auto(void *priv,
+						  rpmi_uint32_t hart_index,
+						  rpmi_uint32_t min_perf,
+						  rpmi_uint32_t max_perf)
+{
+	test_auto_captured_min_perf = min_perf;
+	test_auto_captured_max_perf = max_perf;
+	return RPMI_SUCCESS;
+}
+
 static enum rpmi_error test_cppc_get_current_freq(void *priv,
 						 rpmi_uint32_t hart_index,
 						 rpmi_uint64_t *current_freq_hz)
@@ -188,6 +214,7 @@ static struct rpmi_cppc_platform_ops test_cppc_ops = {
 	.cppc_get_reg = test_cppc_get_reg,
 	.cppc_set_reg = test_cppc_set_reg,
 	.cppc_update_perf = test_cppc_update_perf,
+	.cppc_update_perf_auto = test_cppc_update_perf_auto,
 	.cppc_get_current_freq = test_cppc_get_current_freq,
 };
 
@@ -215,6 +242,76 @@ static rpmi_uint16_t init_fastchan_region_expected(struct rpmi_test_scenario *sc
 	return 12 * sizeof(*exp);
 }
 
+struct test_cppc_scenario_config {
+	enum rpmi_privilege_level privilege_level;
+};
+
+static struct test_cppc_scenario_config cppc_m_mode_config = {
+	.privilege_level = RPMI_PRIVILEGE_M_MODE,
+};
+
+static struct test_cppc_scenario_config cppc_s_mode_config = {
+	.privilege_level = RPMI_PRIVILEGE_S_MODE,
+};
+
+static int test_cppc_scene_base_init(struct rpmi_test_scenario *scene)
+{
+	struct test_cppc_scenario_config *cfg = scene->priv;
+	enum rpmi_privilege_level plevel;
+
+	if (!scene || scene->shm || scene->shmem || scene->xport || scene->cntx)
+		return RPMI_ERR_ALREADY;
+
+	plevel = cfg ? cfg->privilege_level : RPMI_PRIVILEGE_M_MODE;
+
+	scene->shm = rpmi_env_zalloc(scene->shm_size);
+	if (!scene->shm)
+		return RPMI_ERR_FAILED;
+
+	scene->shmem = rpmi_shmem_create("test_shmem",
+					 (unsigned long)scene->shm,
+					 scene->shm_size,
+					 &rpmi_shmem_simple_ops, NULL);
+	if (!scene->shmem) {
+		printf("%s: failed to create test rpmi_shmem\n", __func__);
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->xport = rpmi_transport_shmem_create("test_transport",
+						   scene->slot_size,
+						   ((scene->shm_size * 3) / 4) / 2,
+						   ((scene->shm_size * 1) / 4) / 2,
+						   scene->shmem);
+	if (!scene->xport) {
+		printf("%s: failed to create test rpmi_transport\n", __func__);
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->cntx = rpmi_context_create("test_context", scene->xport,
+					  scene->max_num_groups, plevel,
+					  scene->base.plat_info_len,
+					  scene->base.plat_info);
+	if (!scene->cntx) {
+		printf("%s: failed to create test rpmi_context\n", __func__);
+		rpmi_transport_shmem_destroy(scene->xport);
+		scene->xport = NULL;
+		rpmi_shmem_destroy(scene->shmem);
+		scene->shmem = NULL;
+		rpmi_env_free(scene->shm);
+		scene->shm = NULL;
+		return RPMI_ERR_FAILED;
+	}
+
+	scene->token_sequence = 0;
+	return 0;
+}
+
 static int test_cppc_scenario_init(struct rpmi_test_scenario *scene)
 {
 	struct rpmi_service_group *grp;
@@ -222,7 +319,7 @@ static int test_cppc_scenario_init(struct rpmi_test_scenario *scene)
 	struct rpmi_hsm *hsm;
 	int ret;
 
-	ret = test_scenario_default_init(scene);
+	ret = test_cppc_scene_base_init(scene);
 	if (ret)
 		return RPMI_ERR_FAILED;
 
@@ -262,7 +359,7 @@ static struct rpmi_test_scenario scenario_cppc_default = {
 	.shm_size = RPMI_SHM_SZ,
 	.slot_size = RPMI_SLOT_SIZE,
 	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
-	.priv = NULL,
+	.priv = &cppc_m_mode_config,
 
 	.init = test_cppc_scenario_init,
 	.cleanup = test_scenario_default_cleanup,
@@ -421,8 +518,442 @@ static struct rpmi_test_scenario scenario_cppc_default = {
 	},
 };
 
+/* ---- Autonomous (CPPC2) mode scenario ------------------------------------ */
+
+static rpmi_uint8_t test_auto_fastchan_mem[TEST_CPPC_FASTCHAN_SIZE]
+	__aligned(RPMI_CPPC_FASTCHAN_SIZE);
+
+static struct rpmi_cppc_regs test_cppc_auto_regs = {
+	.highest_perf = TEST_CPPC_HIGHEST_PERF,
+	.nominal_perf = TEST_CPPC_NOMINAL_PERF,
+	.lowest_nonlinear_perf = 0x30,
+	.lowest_perf = 0x10,
+	.guaranteed_perf = TEST_CPPC_GUARANTEED_PERF,
+	.reference_perf = TEST_CPPC_NOMINAL_PERF,
+	.lowest_freq = 1000000000U,
+	.nominal_freq = 2000000000U,
+	.transition_latency = 10,
+	.autonomous_selection_enable = 1,
+	.counter_wraparound_time = ((rpmi_uint64_t)TEST_CPPC_WRAPAROUND_HI << 32) |
+				   TEST_CPPC_WRAPAROUND_LO,
+};
+
+/* PROBE: autonomous-mode-only register → SUCCESS + 32 */
+static rpmi_uint32_t probe_min_perf_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_MIN_PERF,
+};
+
+/* PROBE: both-modes register (64-bit) → SUCCESS + 64 */
+static rpmi_uint32_t probe_wraparound_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_COUNTER_WRAPAROUND_TIME,
+};
+
+static rpmi_uint32_t probe_64bit_expdata[] = {
+	RPMI_SUCCESS, 64,
+};
+
+/* PROBE: guaranteed_perf (both modes, 32-bit) */
+static rpmi_uint32_t probe_guaranteed_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_GUARANTEED_PERF,
+};
+
+/* PROBE: energy_perf_preference (auto only) */
+static rpmi_uint32_t probe_energy_pref_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_ENERGY_PERF_PREFERENCE,
+};
+
+/* READ: guaranteed_perf from regs struct */
+static rpmi_uint32_t read_guaranteed_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_GUARANTEED_PERF,
+};
+
+static rpmi_uint32_t read_guaranteed_expdata[] = {
+	RPMI_SUCCESS, TEST_CPPC_GUARANTEED_PERF, 0,
+};
+
+/* READ: counter_wraparound_time (64-bit) from regs struct */
+static rpmi_uint32_t read_wraparound_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_COUNTER_WRAPAROUND_TIME,
+};
+
+static rpmi_uint32_t read_wraparound_expdata[] = {
+	RPMI_SUCCESS, TEST_CPPC_WRAPAROUND_LO, TEST_CPPC_WRAPAROUND_HI,
+};
+
+/* READ: energy_perf_preference via cppc_get_reg */
+static rpmi_uint32_t read_energy_pref_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_ENERGY_PERF_PREFERENCE,
+};
+
+static rpmi_uint32_t read_energy_pref_expdata[] = {
+	RPMI_SUCCESS, TEST_CPPC_ENERGY_PREF_VAL, 0,
+};
+
+/* WRITE: energy_perf_preference via cppc_set_reg → SUCCESS */
+static rpmi_uint32_t write_energy_pref_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_ENERGY_PERF_PREFERENCE, TEST_CPPC_ENERGY_PREF_VAL, 0,
+};
+
+static rpmi_uint32_t success_expdata[] = {
+	RPMI_SUCCESS,
+};
+
+/* WRITE: min_perf while fastchannel is active → DENIED */
+static rpmi_uint32_t write_min_perf_fc_reqdata[] = {
+	TEST_HART_ID, RPMI_CPPC_MIN_PERF, 0x20, 0,
+};
+
+static rpmi_uint16_t init_auto_event_request(struct rpmi_test_scenario *scene,
+					     struct rpmi_test *test,
+					     void *data, rpmi_uint16_t max_data_len)
+{
+	union rpmi_cppc_perf_request_fastchan *fc =
+		(union rpmi_cppc_perf_request_fastchan *)test_auto_fastchan_mem;
+
+	fc->active.min_perf = TEST_CPPC_AUTO_MIN_PERF;
+	fc->active.max_perf = TEST_CPPC_AUTO_MAX_PERF;
+
+	return test_init_request_data_from_attrs(scene, test, data, max_data_len);
+}
+
+static int verify_auto_event(struct rpmi_test_scenario *scene,
+			     struct rpmi_test *test,
+			     struct rpmi_message *msg)
+{
+	struct rpmi_cppc_perf_feedback_fastchan *fb =
+		(struct rpmi_cppc_perf_feedback_fastchan *)
+		(test_auto_fastchan_mem + RPMI_CPPC_FASTCHAN_SIZE);
+	rpmi_uint64_t freq;
+	int failed = 0;
+
+	if (test_auto_captured_min_perf != TEST_CPPC_AUTO_MIN_PERF ||
+	    test_auto_captured_max_perf != TEST_CPPC_AUTO_MAX_PERF) {
+		printf("%s: cppc_update_perf_auto args: min=%u max=%u (expected min=%u max=%u)\n",
+		       test->name,
+		       test_auto_captured_min_perf, test_auto_captured_max_perf,
+		       TEST_CPPC_AUTO_MIN_PERF, TEST_CPPC_AUTO_MAX_PERF);
+		failed++;
+	}
+
+	freq = ((rpmi_uint64_t)fb->cur_freq_high << 32) | fb->cur_freq_low;
+	if (freq != 2000000000ULL) {
+		printf("%s: feedback cur_freq_hz=%llu (expected 2000000000)\n",
+		       test->name, (unsigned long long)freq);
+		failed++;
+	}
+
+	return failed;
+}
+
+static rpmi_uint16_t init_auto_fastchan_region_expected(struct rpmi_test_scenario *scene,
+							struct rpmi_test *test,
+							void *data,
+							rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *exp = data;
+	rpmi_uint64_t base = (rpmi_uint64_t)(rpmi_uintptr_t)test_auto_fastchan_mem;
+
+	exp[0] = RPMI_SUCCESS;
+	exp[1] = TEST_CPPC_AUTO_FLAGS;
+	exp[2] = (rpmi_uint32_t)base;
+	exp[3] = (rpmi_uint32_t)(base >> 32);
+	exp[4] = TEST_CPPC_FASTCHAN_SIZE;
+	exp[5] = 0;
+	exp[6] = 0;
+	exp[7] = 0;
+	exp[8] = 0;
+	exp[9] = 0;
+	exp[10] = 0;
+	exp[11] = 0;
+
+	return 12 * sizeof(*exp);
+}
+
+static int test_cppc_auto_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct rpmi_service_group *grp;
+	struct rpmi_shmem *fastchan_shmem;
+	struct rpmi_hsm *hsm;
+	int ret;
+
+	ret = test_cppc_scene_base_init(scene);
+	if (ret)
+		return RPMI_ERR_FAILED;
+
+	hsm = rpmi_hsm_create(ARRAY_SIZE(test_hartid_array),
+			      test_hartid_array, 0, NULL, &test_hsm_ops, NULL);
+	if (!hsm) {
+		printf("failed to create rpmi hsm");
+		return RPMI_ERR_FAILED;
+	}
+
+	fastchan_shmem = rpmi_shmem_create("test_cppc_auto_fastchan",
+					   (rpmi_uint64_t)(rpmi_uintptr_t)test_auto_fastchan_mem,
+					   sizeof(test_auto_fastchan_mem),
+					   &rpmi_shmem_simple_ops, NULL);
+	if (!fastchan_shmem) {
+		printf("failed to create cppc auto fastchannel shmem");
+		return RPMI_ERR_FAILED;
+	}
+
+	grp = rpmi_service_group_cppc_create(hsm, &test_cppc_auto_regs,
+					     RPMI_CPPC_AUTO_MODE,
+					     fastchan_shmem,
+					     TEST_CPPC_FASTCHAN_REQ_OFFSET,
+					     TEST_CPPC_FASTCHAN_FB_OFFSET,
+					     &test_cppc_ops, NULL);
+	if (!grp) {
+		printf("failed to create rpmi cppc auto service group");
+		return RPMI_ERR_FAILED;
+	}
+
+	rpmi_context_add_group(scene->cntx, grp);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_cppc_auto = {
+	.name = "CPPC Service Group (Autonomous Mode)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &cppc_m_mode_config,
+
+	.init = test_cppc_auto_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 11,
+	.tests = {
+		{
+			.name = "PROBE MIN_PERF (auto-only, available in auto mode)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_min_perf_reqdata,
+				.request_data_len = sizeof(probe_min_perf_reqdata),
+				.expected_data = probe_32bit_expdata,
+				.expected_data_len = sizeof(probe_32bit_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "PROBE GUARANTEED_PERF (available in both modes)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_guaranteed_reqdata,
+				.request_data_len = sizeof(probe_guaranteed_reqdata),
+				.expected_data = probe_32bit_expdata,
+				.expected_data_len = sizeof(probe_32bit_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "PROBE COUNTER_WRAPAROUND_TIME (64-bit, both modes)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_wraparound_reqdata,
+				.request_data_len = sizeof(probe_wraparound_reqdata),
+				.expected_data = probe_64bit_expdata,
+				.expected_data_len = sizeof(probe_64bit_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "PROBE ENERGY_PERF_PREFERENCE (auto-only)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_energy_pref_reqdata,
+				.request_data_len = sizeof(probe_energy_pref_reqdata),
+				.expected_data = probe_32bit_expdata,
+				.expected_data_len = sizeof(probe_32bit_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "READ GUARANTEED_PERF (from regs struct)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_READ_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = read_guaranteed_reqdata,
+				.request_data_len = sizeof(read_guaranteed_reqdata),
+				.expected_data = read_guaranteed_expdata,
+				.expected_data_len = sizeof(read_guaranteed_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "READ COUNTER_WRAPAROUND_TIME (64-bit from regs struct)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_READ_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = read_wraparound_reqdata,
+				.request_data_len = sizeof(read_wraparound_reqdata),
+				.expected_data = read_wraparound_expdata,
+				.expected_data_len = sizeof(read_wraparound_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "READ ENERGY_PERF_PREFERENCE (via platform cppc_get_reg)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_READ_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = read_energy_pref_reqdata,
+				.request_data_len = sizeof(read_energy_pref_reqdata),
+				.expected_data = read_energy_pref_expdata,
+				.expected_data_len = sizeof(read_energy_pref_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "WRITE ENERGY_PERF_PREFERENCE (via platform cppc_set_reg)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_WRITE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = write_energy_pref_reqdata,
+				.request_data_len = sizeof(write_energy_pref_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "WRITE MIN_PERF (fastchannel present, succeeds)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_WRITE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = write_min_perf_fc_reqdata,
+				.request_data_len = sizeof(write_min_perf_fc_reqdata),
+				.expected_data = success_expdata,
+				.expected_data_len = sizeof(success_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET FAST CHANNEL REGION (auto mode flags)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_GET_FAST_CHANNEL_REGION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+			},
+			.init_expected_data = init_auto_fastchan_region_expected,
+		},
+		{
+			.name = "EVENT: fastchan min/max triggers auto callback+feedback",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_highest_reqdata,
+				.request_data_len = sizeof(probe_highest_reqdata),
+				.expected_data = probe_32bit_expdata,
+				.expected_data_len = sizeof(probe_32bit_expdata),
+			},
+			.init_request_data = init_auto_event_request,
+			.init_expected_data = test_init_expected_data_from_attrs,
+			.verify = verify_auto_event,
+		},
+	},
+};
+
+static struct rpmi_test_scenario scenario_cppc_s_mode = {
+	.name = "CPPC Service Group (S-mode)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &cppc_s_mode_config,
+
+	.init = test_cppc_auto_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 4,
+	.tests = {
+		{
+			.name = "PROBE HIGHEST_PERF (S-mode access)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_highest_reqdata,
+				.request_data_len = sizeof(probe_highest_reqdata),
+				.expected_data = probe_32bit_expdata,
+				.expected_data_len = sizeof(probe_32bit_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "READ HIGHEST_PERF (S-mode access)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_READ_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = read_highest_reqdata,
+				.request_data_len = sizeof(read_highest_reqdata),
+				.expected_data = read_highest_expdata,
+				.expected_data_len = sizeof(read_highest_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "PROBE MIN_PERF (S-mode access, autonomous mode)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_PROBE_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = probe_min_perf_reqdata,
+				.request_data_len = sizeof(probe_min_perf_reqdata),
+				.expected_data = probe_32bit_expdata,
+				.expected_data_len = sizeof(probe_32bit_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "READ GUARANTEED_PERF (S-mode access, autonomous mode)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_READ_REG,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = read_guaranteed_reqdata,
+				.request_data_len = sizeof(read_guaranteed_reqdata),
+				.expected_data = read_guaranteed_expdata,
+				.expected_data_len = sizeof(read_guaranteed_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+	},
+};
+
 int main(int argc, char *argv[])
 {
+	int ret = 0;
+
 	printf("Test CPPC Service Group\n");
-	return test_scenario_execute(&scenario_cppc_default);
+	ret |= test_scenario_execute(&scenario_cppc_default);
+	ret |= test_scenario_execute(&scenario_cppc_auto);
+	ret |= test_scenario_execute(&scenario_cppc_s_mode);
+	return ret;
 }

--- a/test/test_srvgrp_cppc.c
+++ b/test/test_srvgrp_cppc.c
@@ -235,11 +235,8 @@ static rpmi_uint16_t init_fastchan_region_expected(struct rpmi_test_scenario *sc
 	exp[6] = 0;
 	exp[7] = 0;
 	exp[8] = 0;
-	exp[9] = 0;
-	exp[10] = 0;
-	exp[11] = 0;
 
-	return 12 * sizeof(*exp);
+	return 9 * sizeof(*exp);
 }
 
 struct test_cppc_scenario_config {
@@ -662,11 +659,8 @@ static rpmi_uint16_t init_auto_fastchan_region_expected(struct rpmi_test_scenari
 	exp[6] = 0;
 	exp[7] = 0;
 	exp[8] = 0;
-	exp[9] = 0;
-	exp[10] = 0;
-	exp[11] = 0;
 
-	return 12 * sizeof(*exp);
+	return 9 * sizeof(*exp);
 }
 
 static int test_cppc_auto_scenario_init(struct rpmi_test_scenario *scene)


### PR DESCRIPTION
This PR implements autonomous (CPPC2) mode support for the CPPC service group as per the RPMI specification.

## Overview
Adds full support for autonomous mode alongside the existing passive (normal) mode. In autonomous mode the application processor provides minimum and maximum performance bounds via the fastchannel, and the platform firmware selects the actual operating point within those bounds. This is in contrast to passive mode where the AP writes an explicit desired performance level.

Also fixes a spec compliance issue in CPPC_PROBE_REG: a valid but mode-unsupported register must return SUCCESS with REG_LENGTH=0, not RPMI_ERR_NOTSUPP.

## Changes

### Library Implementation (lib/rpmi_service_group_cppc.c)
- Added cppc_update_perf_auto() platform callback for autonomous mode performance bound updates
- Unlocked RPMI_CPPC_AUTO_MODE in the create function and store the mode at runtime
- Implemented probe, read, and write for the 10 previously unimplemented registers, gating autonomous-only registers on mode
- Added autonomous mode event loop reading min_perf/max_perf from the fastchannel active union
GET_FAST_CHANNEL_REGION now encodes FLAGS[4:3] = 0b01 for autonomous mode

### Public API (include/librpmi.h)

- Added cppc_update_perf_auto() callback to rpmi_cppc_platform_ops for autonomous mode performance bound updates

### Tests (test/test_srvgrp_cppc.c)

- Updated probe_not_supp_expdata to expect SUCCESS + REG_LENGTH=0 following the spec compliance fix
- Added test_cppc_update_perf_auto() stub and wired it into the shared test_cppc_ops
- Added scenario_cppc_auto with 10 test cases covering:
PROBE_REG for autonomous-only registers returns SUCCESS + 32 in autonomous mode
PROBE_REG for both-modes registers (GUARANTEED_PERF, COUNTER_WRAPAROUND_TIME) returns correct lengths
READ_REG for GUARANTEED_PERF and COUNTER_WRAPAROUND_TIME from the static regs struct
READ_REG and WRITE_REG for ENERGY_PERF_PREFERENCE via platform callbacks
WRITE_REG for MIN_PERF returns DENIED when fastchannel is active
GET_FAST_CHANNEL_REGION returns FLAGS = 0x08 in autonomous mode
- Updated main() to run both passive and autonomous scenarios

### Testing

- [x] `make` - builds successfully without warnings
- [x] `make check` - all tests pass
- [x] `make LIBRPMI_TEST=y` - builds with tests successfully

All existing passive mode tests continue to pass

## Compliance
Implements autonomous (CPPC2) mode for the CPPC service group as specified in the RISC-V RPMI specification. .