### PR TITLE
voltage: fix status reporting and linear range level packing

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -1958,6 +1958,10 @@ enum rpmi_voltage_type {
 	(((__format) & RPMI_VOLT_CAPABILITY_FORMAT_MASK) <<		\
 	 RPMI_VOLT_CAPABILITY_FORMAT_POS)
 
+#define RPMI_VOLT_CAPABILITY_GET_FORMAT(__capability)			\
+	(((__capability) >> RPMI_VOLT_CAPABILITY_FORMAT_POS) &		\
+	 RPMI_VOLT_CAPABILITY_FORMAT_MASK)
+
 /** voltage domain capabilities */
 enum rpmi_voltage_capability {
 	RPMI_VOLT_CAPABILITY_INVALID		= -1,
@@ -1990,6 +1994,18 @@ struct rpmi_voltage_linear_range {
  * This structure represents the static
  * voltage domain data which platform has to maintain
  * and pass to create the voltage service group.
+ *
+ * The layout of the voltage level array depends on voltage_type. The
+ * num_levels field below, the MAX_NUM_LEVELS returned by VOLT_GET_ATTRIBUTES
+ * and the RETURNED and REMAINING counts of VOLT_GET_SUPPORTED_LEVELS all
+ * count voltage levels, never words:
+ *
+ * RPMI_VOLT_TYPE_DISCRETE: discrete_levels is one word per level and holds
+ * num_levels words.
+ *
+ * RPMI_VOLT_TYPE_LINEAR: linear_levels is a flattened array of
+ * (uvolt_min, uvolt_max, uvolt_step) tuples, three words per level, and
+ * holds num_levels * 3 words.
  */
 struct rpmi_voltage_data {
 	/* voltage domain name */
@@ -2000,7 +2016,7 @@ struct rpmi_voltage_data {
 	rpmi_uint32_t				control;
 	/* regulator config */
 	rpmi_uint32_t				config;
-	/** number of supported voltage levels */
+	/** number of supported voltage levels (discrete levels or linear ranges) */
 	rpmi_uint32_t				num_levels;
 	/** transition latency */
 	rpmi_uint32_t				trans_latency;
@@ -2008,9 +2024,13 @@ struct rpmi_voltage_data {
         struct rpmi_voltage_discrete_range	*discrete_range;
         /** linear voltage range */
         struct rpmi_voltage_linear_range	*linear_range;
-	/** discrete voltage levels */
+	/** discrete voltage levels, one word per level, num_levels words */
 	rpmi_int32_t				*discrete_levels;
-	/** linear voltage levels */
+	/**
+	 * linear voltage levels, a flattened array of
+	 * (uvolt_min, uvolt_max, uvolt_step) tuples, three words per
+	 * level, num_levels * 3 words
+	 */
 	rpmi_int32_t				*linear_levels;
 	/** voltage level */
 	rpmi_int32_t				level_uv;
@@ -2028,7 +2048,12 @@ struct rpmi_voltage_attrs {
 	rpmi_uint32_t	num_levels;
 	/* transition latency */
 	rpmi_uint32_t	trans_latency;
-	/** array of supported levels */
+	/**
+	 * array of supported levels, either the discrete_levels or the
+	 * linear_levels array of struct rpmi_voltage_data selected by the
+	 * voltage format in capability, with the word-per-level layout
+	 * documented there
+	 */
 	rpmi_int32_t	*level_array;
 	/* voltage domain name */
 	const char	*name;
@@ -2065,7 +2090,14 @@ struct rpmi_voltage_platform_ops {
 				     rpmi_int32_t *volt_level);
 
 	/**
-	 * Get perf supported levels
+	 * Get voltage supported levels
+	 *
+	 * The max, volt_index and returned_levels parameters count voltage
+	 * levels, not words. The callback writes returned_levels levels into
+	 * level_array starting at level volt_index, which is
+	 * returned_levels words for a discrete domain and
+	 * returned_levels * 3 words for a linear domain, and never more
+	 * than max levels.
 	 **/
 	enum rpmi_error (*get_supp_levels)(void *priv,
 					   rpmi_uint32_t volt_id,

--- a/lib/rpmi_service_group_voltage.c
+++ b/lib/rpmi_service_group_voltage.c
@@ -9,22 +9,20 @@
 #include "librpmi_internal_list.h"
 
 #ifdef LIBRPMI_DEBUG
-#define DPRINTF(msg...)         rpmi_env_printf(msg)
+#define DPRINTF(msg...)		rpmi_env_printf(msg)
 #else
 #define DPRINTF(msg...)
 #endif
 
 #define RPMI_VOLT_NAME_MAX_LEN  16
 
-/** Convert list node pointer to struct rpmi_voltage instance pointer */
-#define to_rpmi_voltage(__node)    \
+/* Convert list node pointer to struct rpmi_voltage instance pointer */
+#define to_rpmi_voltage(__node)		\
 	container_of((__node), struct rpmi_voltage_data, node)
 
 /* A voltage domain instance */
 struct rpmi_voltage {
-	/* Lock to invoke the platform operations to
-	 * protect this structure
-	 */
+	/* Lock to invoke the platform operations to protect this structure */
 	void *lock;
 	/* domain ID */
 	rpmi_uint32_t id;
@@ -32,22 +30,22 @@ struct rpmi_voltage {
 	const struct rpmi_voltage_data *vdata;
 };
 
-/** RPMI Voltage Service Group instance */
+/* RPMI Voltage Service Group instance */
 struct rpmi_voltage_group {
 	/* Total domains count */
 	rpmi_uint32_t volt_count;
 	/* Pointer to voltage domains tree */
 	struct rpmi_voltage *volt_tree;
-	/* Common voltage platform operations (called with holding the lock)*/
+	/* Common voltage platform operations (called with holding the lock) */
 	const struct rpmi_voltage_platform_ops *ops;
 	/* Private data of platform voltage operations */
 	void *ops_priv;
 	struct rpmi_service_group group;
 };
 
-/** Get a struct rpmi_voltage instance pointer from voltage domain id */
-static inline struct rpmi_voltage *
-rpmi_get_voltage(struct rpmi_voltage_group *volt_group, rpmi_uint32_t volt_id)
+/* Get a struct rpmi_voltage instance pointer from voltage domain id */
+static inline struct rpmi_voltage
+*rpmi_get_voltage(struct rpmi_voltage_group *volt_group, rpmi_uint32_t volt_id)
 {
 	return &volt_group->volt_tree[volt_id];
 }
@@ -127,7 +125,6 @@ static enum rpmi_error __rpmi_volt_get_config(struct rpmi_voltage_group *voltgrp
 	rpmi_env_lock(volt->lock);
 
 	ret = voltgrp->ops->get_config(voltgrp->ops_priv, volt->id, &config);
-
 	*volt_config = config;
 
 	rpmi_env_unlock(volt->lock);
@@ -175,9 +172,7 @@ static enum rpmi_error __rpmi_volt_get_level(struct rpmi_voltage_group *voltgrp,
 		return RPMI_ERR_INVALID_PARAM;
 
 	rpmi_env_lock(volt->lock);
-
 	ret = voltgrp->ops->get_level(voltgrp->ops_priv, volt->id, volt_level);
-
 	rpmi_env_unlock(volt->lock);
 
 	return ret;
@@ -190,30 +185,28 @@ static enum rpmi_error __rpmi_volt_set_level(struct rpmi_voltage_group *voltgrp,
 	enum rpmi_error ret;
 	struct rpmi_voltage *volt = rpmi_get_voltage(voltgrp, voltid);
 
-        if (!volt)
-                return RPMI_ERR_INVALID_PARAM;
+	if (!volt)
+		return RPMI_ERR_INVALID_PARAM;
 
-        rpmi_env_lock(volt->lock);
+	rpmi_env_lock(volt->lock);
+	ret = voltgrp->ops->set_level(voltgrp->ops_priv, volt->id, volt_level);
+	rpmi_env_unlock(volt->lock);
 
-        ret = voltgrp->ops->set_level(voltgrp->ops_priv, volt->id, volt_level);
-
-        rpmi_env_unlock(volt->lock);
-
-        return ret;
+	return ret;
 }
 
-/**
+/*
  * Initialize the voltage tree from provided
  * static platform voltage data.
  *
  * This function initializes the hierarchical structures
  * to represent the voltage association in the platform.
- **/
-static struct rpmi_voltage *
-rpmi_voltage_tree_init(rpmi_uint32_t volt_count,
-		       const struct rpmi_voltage_data *volt_tree_data,
-		       const struct rpmi_voltage_platform_ops *ops,
-		       void *ops_priv)
+ */
+static struct rpmi_voltage
+*rpmi_voltage_tree_init(rpmi_uint32_t volt_count,
+			const struct rpmi_voltage_data *volt_tree_data,
+			const struct rpmi_voltage_platform_ops *ops,
+			void *ops_priv)
 {
 	rpmi_uint32_t voltid;
 	struct rpmi_voltage *volt;
@@ -291,9 +284,7 @@ rpmi_volt_get_attributes(struct rpmi_service_group *group,
 	}
 
 	resp[1] = rpmi_to_xe32(trans->is_be, volt_attrs.capability);
-
 	resp[2] = rpmi_to_xe32(trans->is_be, volt_attrs.num_levels);
-
 	resp[3] = rpmi_to_xe32(trans->is_be, volt_attrs.trans_latency);
 
 	if (volt_attrs.name)
@@ -309,12 +300,12 @@ done:
 
 static enum rpmi_error
 rpmi_volt_get_config(struct rpmi_service_group *group,
-		    struct rpmi_service *service,
-		    struct rpmi_transport *trans,
-		    rpmi_uint16_t request_datalen,
-		    const rpmi_uint8_t *request_data,
-		    rpmi_uint16_t *response_datalen,
-		    rpmi_uint8_t *response_data)
+		     struct rpmi_service *service,
+		     struct rpmi_transport *trans,
+		     rpmi_uint16_t request_datalen,
+		     const rpmi_uint8_t *request_data,
+		     rpmi_uint16_t *response_datalen,
+		     rpmi_uint8_t *response_data)
 {
 	rpmi_uint16_t resp_dlen;
 	rpmi_uint32_t volt_config = 0;
@@ -341,11 +332,11 @@ rpmi_volt_get_config(struct rpmi_service_group *group,
 
 	resp[1] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)volt_config);
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
-
 	resp_dlen = 2 * sizeof(*resp);
 
 done:
 	*response_datalen = resp_dlen;
+
 	return RPMI_SUCCESS;
 }
 
@@ -364,9 +355,9 @@ rpmi_volt_set_config(struct rpmi_service_group *group,
 	rpmi_uint32_t *resp = (void *)response_data;
 
 	rpmi_uint32_t voltid = rpmi_to_xe32(trans->is_be,
-					((const rpmi_uint32_t *)request_data)[0]);
+					    ((const rpmi_uint32_t *)request_data)[0]);
 	rpmi_uint32_t volt_config = rpmi_to_xe32(trans->is_be,
-					((const rpmi_uint32_t *)request_data)[1]);
+						 ((const rpmi_uint32_t *)request_data)[1]);
 
 	if (voltid >= voltgrp->volt_count) {
 		resp[0] = rpmi_to_xe32(trans->is_be,
@@ -388,93 +379,93 @@ rpmi_volt_set_config(struct rpmi_service_group *group,
 
 done:
 	*response_datalen = resp_dlen;
+
 	return RPMI_SUCCESS;
 }
 
 static enum rpmi_error
 rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
-                          struct rpmi_service *service,
-                          struct rpmi_transport *trans,
-                          rpmi_uint16_t request_datalen,
-                          const rpmi_uint8_t *request_data,
-                          rpmi_uint16_t *response_datalen,
-                          rpmi_uint8_t *response_data)
+			  struct rpmi_service *service,
+			  struct rpmi_transport *trans,
+			  rpmi_uint16_t request_datalen,
+			  const rpmi_uint8_t *request_data,
+			  rpmi_uint16_t *response_datalen,
+			  rpmi_uint8_t *response_data)
 {
-        enum rpmi_error ret;
-        rpmi_uint32_t i;
-        rpmi_uint32_t num_volt_level;
-        rpmi_uint32_t resp_dlen = 0, volt_level_idx = 0;
-        rpmi_uint32_t max_levels, remaining = 0, returned = 0;
+	enum rpmi_error ret;
+	rpmi_uint32_t i;
+	rpmi_uint32_t num_volt_level;
+	rpmi_uint32_t resp_dlen = 0, volt_level_idx = 0;
+	rpmi_uint32_t max_levels, remaining = 0, returned = 0;
 	rpmi_uint32_t start;
-        rpmi_int32_t *volt_level_array;
-        struct rpmi_voltage_attrs volt_attrs;
-        struct rpmi_voltage_group *voltgrp = group->priv;
-        rpmi_uint32_t *resp = (void *)response_data;
+	rpmi_int32_t *volt_level_array;
+	struct rpmi_voltage_attrs volt_attrs;
+	struct rpmi_voltage_group *voltgrp = group->priv;
+	rpmi_uint32_t *resp = (void *)response_data;
 
-        rpmi_uint32_t voltid = rpmi_to_xe32(trans->is_be,
-                                ((const rpmi_uint32_t *)request_data)[0]);
+	rpmi_uint32_t voltid = rpmi_to_xe32(trans->is_be,
+					    ((const rpmi_uint32_t *)request_data)[0]);
 
-        if (voltid >= voltgrp->volt_count) {
-                resp_dlen = sizeof(*resp);
-                resp[0] = rpmi_to_xe32(trans->is_be,
-                                       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
-                goto done;
-        }
+	if (voltid >= voltgrp->volt_count) {
+		resp_dlen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be,
+				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		goto done;
+	}
 
-        ret = __rpmi_volt_get_attributes(voltgrp, voltid, &volt_attrs);
-        if (ret) {
-                resp_dlen = sizeof(*resp);
-                resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
-                goto done;
-        }
+	ret = __rpmi_volt_get_attributes(voltgrp, voltid, &volt_attrs);
+	if (ret) {
+		resp_dlen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
+		goto done;
+	}
 
-        num_volt_level = volt_attrs.num_levels;
-        volt_level_array = volt_attrs.level_array;
+	num_volt_level = volt_attrs.num_levels;
+	volt_level_array = volt_attrs.level_array;
 
-        if (!num_volt_level || !volt_level_array) {
-                resp_dlen = sizeof(*resp);
-                resp[0] = rpmi_to_xe32(trans->is_be,
-                                       (rpmi_uint32_t)RPMI_ERR_NOTSUPP);
-                goto done;
-        }
+	if (!num_volt_level || !volt_level_array) {
+		resp_dlen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be,
+				       (rpmi_uint32_t)RPMI_ERR_NOTSUPP);
+		goto done;
+	}
 
-        volt_level_idx = rpmi_to_xe32(trans->is_be,
-                                      ((const rpmi_uint32_t *)request_data)[1]);
+	volt_level_idx = rpmi_to_xe32(trans->is_be,
+				      ((const rpmi_uint32_t *)request_data)[1]);
 
-        /* max volt levels a rpmi message can accommodate */
-        max_levels =
-                (RPMI_MSG_DATA_SIZE(trans->slot_size) - (4 * sizeof(*resp))) /
-                                        sizeof(rpmi_int32_t);
+	/* max volt levels a rpmi message can accommodate */
+	max_levels =
+		(RPMI_MSG_DATA_SIZE(trans->slot_size) - (4 * sizeof(*resp))) /
+					sizeof(rpmi_int32_t);
 
-        ret = __rpmi_volt_get_supp_levels(voltgrp, volt_level_array, max_levels,
-                                          voltid, volt_level_idx, &returned);
-        if (ret) {
-                resp_dlen = sizeof(*resp);
-                resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
-                goto done;
-        }
+	ret = __rpmi_volt_get_supp_levels(voltgrp, volt_level_array, max_levels,
+					  voltid, volt_level_idx, &returned);
+	if (ret) {
+		resp_dlen = sizeof(*resp);
+		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
+		goto done;
+	}
 
-        for (i = 0; i < returned; i++) {
-                start = 4;
-                resp[start + i] = rpmi_to_xe32(trans->is_be,
-                                        (rpmi_uint32_t)volt_level_array[i]);
-        }
+	for (i = 0; i < returned; i++) {
+		start = 4;
+		resp[start + i] = rpmi_to_xe32(trans->is_be,
+					   (rpmi_uint32_t)volt_level_array[i]);
+	}
 
-       remaining = num_volt_level - (volt_level_idx + returned);
+	remaining = num_volt_level - (volt_level_idx + returned);
 
-        resp[3] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)returned);
-        resp[2] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)remaining);
-        /* No flags currently supported */
-        resp[1] = rpmi_to_xe32(trans->is_be, 0);
-        resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
+	resp[3] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)returned);
+	resp[2] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)remaining);
+	/* No flags currently supported */
+	resp[1] = rpmi_to_xe32(trans->is_be, 0);
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
 
-        resp_dlen = (4 * sizeof(*resp)) +
-                        (returned * sizeof(rpmi_uint32_t));
+	resp_dlen = (4 * sizeof(*resp)) + (returned * sizeof(rpmi_uint32_t));
 
 done:
-        *response_datalen = resp_dlen;
+	*response_datalen = resp_dlen;
 
-        return RPMI_SUCCESS;
+	return RPMI_SUCCESS;
 }
 
 static enum rpmi_error
@@ -511,12 +502,11 @@ rpmi_volt_get_level(struct rpmi_service_group *group,
 
 	resp[1] = rpmi_to_xe32(trans->is_be, (rpmi_int32_t)volt_level);
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
-
 	resp_dlen = 2 * sizeof(*resp);
 
 done:
-
 	*response_datalen = resp_dlen;
+
 	return RPMI_SUCCESS;
 }
 
@@ -535,9 +525,9 @@ rpmi_volt_set_level(struct rpmi_service_group *group,
 	rpmi_uint32_t *resp = (void *)response_data;
 
 	rpmi_uint32_t voltid = rpmi_to_xe32(trans->is_be,
-					((const rpmi_uint32_t *)request_data)[0]);
+					    ((const rpmi_uint32_t *)request_data)[0]);
 	rpmi_int32_t volt_level = rpmi_to_xe32(trans->is_be,
-					((const rpmi_uint32_t *)request_data)[1]);
+					       ((const rpmi_uint32_t *)request_data)[1]);
 
 	if (voltid >= voltgrp->volt_count) {
 		resp[0] = rpmi_to_xe32(trans->is_be,
@@ -554,11 +544,11 @@ rpmi_volt_set_level(struct rpmi_service_group *group,
 	}
 
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
-
 	resp_dlen = sizeof(*resp);
 
 done:
 	*response_datalen = resp_dlen;
+
 	return RPMI_SUCCESS;
 }
 
@@ -605,11 +595,11 @@ static struct rpmi_service rpmi_voltage_services[RPMI_VOLT_SRV_ID_MAX] = {
 	},
 };
 
-struct rpmi_service_group *
-rpmi_service_group_voltage_create(rpmi_uint32_t volt_count,
-				  const struct rpmi_voltage_data *volt_tree_data,
-				  const struct rpmi_voltage_platform_ops *ops,
-				  void *ops_priv)
+struct rpmi_service_group
+*rpmi_service_group_voltage_create(rpmi_uint32_t volt_count,
+				   const struct rpmi_voltage_data *volt_tree_data,
+				   const struct rpmi_voltage_platform_ops *ops,
+				   void *ops_priv)
 {
 	struct rpmi_voltage_group *voltgrp;
 	struct rpmi_service_group *group;
@@ -628,10 +618,8 @@ rpmi_service_group_voltage_create(rpmi_uint32_t volt_count,
 		return NULL;
 	}
 
-	voltgrp->volt_tree = rpmi_voltage_tree_init(volt_count,
-						    volt_tree_data,
-						    ops,
-						    ops_priv);
+	voltgrp->volt_tree = rpmi_voltage_tree_init(volt_count, volt_tree_data,
+						    ops, ops_priv);
 	if (!voltgrp->volt_tree) {
 		DPRINTF("%s: failed to initialize voltage tree\n", __func__);
 		rpmi_env_free(voltgrp);

--- a/lib/rpmi_service_group_voltage.c
+++ b/lib/rpmi_service_group_voltage.c
@@ -383,7 +383,7 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 	rpmi_uint32_t num_volt_level;
 	rpmi_uint32_t resp_dlen = 0, volt_level_idx = 0;
 	rpmi_uint32_t max_levels, remaining = 0, returned = 0;
-	rpmi_uint32_t start;
+	rpmi_uint32_t words_per_level;
 	rpmi_int32_t *volt_level_array;
 	struct rpmi_voltage_attrs volt_attrs;
 	struct rpmi_voltage_group *voltgrp = group->priv;
@@ -416,10 +416,20 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 	volt_level_idx = rpmi_to_xe32(trans->is_be,
 				      ((const rpmi_uint32_t *)request_data)[1]);
 
+	/*
+	 * A discrete level is one word while a linear range level is a
+	 * (min, max, step) tuple of three. NUM_LEVELS, RETURNED and REMAINING
+	 * all count levels, so the width of a level is needed both to size the
+	 * reply and to know how many levels fit in one message.
+	 */
+	words_per_level =
+		RPMI_VOLT_CAPABILITY_GET_FORMAT(volt_attrs.capability) ==
+		RPMI_VOLT_TYPE_LINEAR ? 3 : 1;
+
 	/* max volt levels a rpmi message can accommodate */
 	max_levels =
 		(RPMI_MSG_DATA_SIZE(trans->slot_size) - (4 * sizeof(*resp))) /
-					sizeof(rpmi_int32_t);
+		(sizeof(rpmi_int32_t) * words_per_level);
 
 	ret = __rpmi_volt_get_supp_levels(voltgrp, volt_level_array, max_levels,
 					  voltid, volt_level_idx, &returned);
@@ -428,9 +438,8 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 		goto done;
 	}
 
-	for (i = 0; i < returned; i++) {
-		start = 4;
-		resp[start + i] = rpmi_to_xe32(trans->is_be,
+	for (i = 0; i < returned * words_per_level; i++) {
+		resp[4 + i] = rpmi_to_xe32(trans->is_be,
 					   (rpmi_uint32_t)volt_level_array[i]);
 	}
 
@@ -441,7 +450,8 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 	/* No flags currently supported */
 	resp[1] = rpmi_to_xe32(trans->is_be, 0);
 
-	resp_dlen = (4 * sizeof(*resp)) + (returned * sizeof(rpmi_uint32_t));
+	resp_dlen = (4 * sizeof(*resp)) +
+		    (returned * words_per_level * sizeof(rpmi_uint32_t));
 
 done:
 	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);

--- a/lib/rpmi_service_group_voltage.c
+++ b/lib/rpmi_service_group_voltage.c
@@ -270,16 +270,14 @@ rpmi_volt_get_attributes(struct rpmi_service_group *group,
 					    ((const rpmi_uint32_t *)request_data)[0]);
 
 	if (voltid >= voltgrp->volt_count) {
+		ret = RPMI_ERR_INVALID_PARAM;
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
 		goto done;
 	}
 
 	ret = __rpmi_volt_get_attributes(voltgrp, voltid, &volt_attrs);
 	if (ret) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 		goto done;
 	}
 
@@ -293,6 +291,7 @@ rpmi_volt_get_attributes(struct rpmi_service_group *group,
 	resp_dlen = 4 * sizeof(*resp) + RPMI_VOLT_NAME_MAX_LEN;
 
 done:
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 	*response_datalen = resp_dlen;
 
 	return RPMI_SUCCESS;
@@ -317,8 +316,7 @@ rpmi_volt_get_config(struct rpmi_service_group *group,
 					    ((const rpmi_uint32_t *)request_data)[0]);
 
 	if (voltid >= voltgrp->volt_count) {
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		ret = RPMI_ERR_INVALID_PARAM;
 		resp_dlen = sizeof(*resp);
 		goto done;
 	}
@@ -326,15 +324,14 @@ rpmi_volt_get_config(struct rpmi_service_group *group,
 	ret = __rpmi_volt_get_config(voltgrp, voltid, &volt_config);
 	if (ret) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 		goto done;
 	}
 
 	resp[1] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)volt_config);
-	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
 	resp_dlen = 2 * sizeof(*resp);
 
 done:
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 	*response_datalen = resp_dlen;
 
 	return RPMI_SUCCESS;
@@ -349,7 +346,6 @@ rpmi_volt_set_config(struct rpmi_service_group *group,
 		     rpmi_uint16_t *response_datalen,
 		     rpmi_uint8_t *response_data)
 {
-	rpmi_uint16_t resp_dlen;
 	enum rpmi_error ret;
 	struct rpmi_voltage_group *voltgrp = group->priv;
 	rpmi_uint32_t *resp = (void *)response_data;
@@ -360,25 +356,15 @@ rpmi_volt_set_config(struct rpmi_service_group *group,
 						 ((const rpmi_uint32_t *)request_data)[1]);
 
 	if (voltid >= voltgrp->volt_count) {
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
-		resp_dlen = sizeof(*resp);
+		ret = RPMI_ERR_INVALID_PARAM;
 		goto done;
 	}
 
 	ret = __rpmi_volt_set_config(voltgrp, voltid, volt_config);
-	if (ret) {
-		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
-		goto done;
-	}
-
-	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
-
-	resp_dlen = sizeof(*resp);
 
 done:
-	*response_datalen = resp_dlen;
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
+	*response_datalen = sizeof(*resp);
 
 	return RPMI_SUCCESS;
 }
@@ -408,15 +394,13 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 
 	if (voltid >= voltgrp->volt_count) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		ret = RPMI_ERR_INVALID_PARAM;
 		goto done;
 	}
 
 	ret = __rpmi_volt_get_attributes(voltgrp, voltid, &volt_attrs);
 	if (ret) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 		goto done;
 	}
 
@@ -425,8 +409,7 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 
 	if (!num_volt_level || !volt_level_array) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_NOTSUPP);
+		ret = RPMI_ERR_NOTSUPP;
 		goto done;
 	}
 
@@ -442,7 +425,6 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 					  voltid, volt_level_idx, &returned);
 	if (ret) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 		goto done;
 	}
 
@@ -458,11 +440,11 @@ rpmi_volt_get_supp_levels(struct rpmi_service_group *group,
 	resp[2] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)remaining);
 	/* No flags currently supported */
 	resp[1] = rpmi_to_xe32(trans->is_be, 0);
-	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
 
 	resp_dlen = (4 * sizeof(*resp)) + (returned * sizeof(rpmi_uint32_t));
 
 done:
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 	*response_datalen = resp_dlen;
 
 	return RPMI_SUCCESS;
@@ -487,8 +469,7 @@ rpmi_volt_get_level(struct rpmi_service_group *group,
 					    ((const rpmi_uint32_t *)request_data)[0]);
 
 	if (voltid >= voltgrp->volt_count) {
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
+		ret = RPMI_ERR_INVALID_PARAM;
 		resp_dlen = sizeof(*resp);
 		goto done;
 	}
@@ -496,15 +477,14 @@ rpmi_volt_get_level(struct rpmi_service_group *group,
 	ret = __rpmi_volt_get_level(voltgrp, voltid, &volt_level);
 	if (ret) {
 		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 		goto done;
 	}
 
 	resp[1] = rpmi_to_xe32(trans->is_be, (rpmi_int32_t)volt_level);
-	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
 	resp_dlen = 2 * sizeof(*resp);
 
 done:
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
 	*response_datalen = resp_dlen;
 
 	return RPMI_SUCCESS;
@@ -519,7 +499,6 @@ rpmi_volt_set_level(struct rpmi_service_group *group,
 		    rpmi_uint16_t *response_datalen,
 		    rpmi_uint8_t *response_data)
 {
-	rpmi_uint16_t resp_dlen;
 	enum rpmi_error ret;
 	struct rpmi_voltage_group *voltgrp = group->priv;
 	rpmi_uint32_t *resp = (void *)response_data;
@@ -530,24 +509,15 @@ rpmi_volt_set_level(struct rpmi_service_group *group,
 					       ((const rpmi_uint32_t *)request_data)[1]);
 
 	if (voltid >= voltgrp->volt_count) {
-		resp[0] = rpmi_to_xe32(trans->is_be,
-				       (rpmi_uint32_t)RPMI_ERR_INVALID_PARAM);
-		resp_dlen = sizeof(*resp);
+		ret = RPMI_ERR_INVALID_PARAM;
 		goto done;
 	}
 
 	ret = __rpmi_volt_set_level(voltgrp, voltid, &volt_level);
-	if (ret) {
-		resp_dlen = sizeof(*resp);
-		resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
-		goto done;
-	}
-
-	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)RPMI_SUCCESS);
-	resp_dlen = sizeof(*resp);
 
 done:
-	*response_datalen = resp_dlen;
+	resp[0] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)ret);
+	*response_datalen = sizeof(*resp);
 
 	return RPMI_SUCCESS;
 }

--- a/test/test_srvgrp_voltage.c
+++ b/test/test_srvgrp_voltage.c
@@ -8,18 +8,27 @@
 #include "test_common.h"
 #include "test_log.h"
 
-#define TEST_VOLT_COUNT		2
+#define TEST_VOLT_COUNT		4
 #define TEST_VOLT_CPU		0
 #define TEST_VOLT_MEM		1
+#define TEST_VOLT_PAGED_D	2
+#define TEST_VOLT_PAGED_L	3
 #define TEST_VOLT_INVALID	TEST_VOLT_COUNT
 #define TEST_EVENT_ID		0x0
 #define TEST_REQUEST_STATE_ENABLE	0x1
 #define TEST_VOLT_CPU_LATENCY	10
 #define TEST_VOLT_MEM_LATENCY	20
+#define TEST_VOLT_PAGED_LATENCY	30
 #define TEST_VOLT_CPU_INITIAL	800000
 #define TEST_VOLT_CPU_TARGET	1000000
 #define TEST_VOLT_CPU_UNSUPP	1100000
 #define TEST_VOLT_BAD_CONFIG	RPMI_VOLT_CONFIG_MAX
+
+#define TEST_VOLT_LEVELS_PER_MSG					\
+	((RPMI_MSG_DATA_SIZE(RPMI_SLOT_SIZE) -				\
+	  (4 * sizeof(rpmi_uint32_t))) / sizeof(rpmi_uint32_t))
+#define TEST_VOLT_TUPLES_PER_MSG					\
+	(TEST_VOLT_LEVELS_PER_MSG / ARRAY_SIZE(test_paged_l_levels[0]))
 
 struct test_volt_attrs_expdata {
 	rpmi_uint32_t status;
@@ -50,6 +59,47 @@ static struct rpmi_voltage_linear_range test_mem_range = {
 	.uvolt_step = 100000,
 };
 
+static rpmi_int32_t test_mem_tuples[][3] = {
+	{ 1800000, 1900000, 100000 },
+};
+
+static rpmi_int32_t test_paged_d_levels[] = {
+	600000,
+	625000,
+	650000,
+	675000,
+	700000,
+	725000,
+	750000,
+	775000,
+	800000,
+	825000,
+	850000,
+	875000,
+};
+
+static rpmi_int32_t test_paged_d_buf[ARRAY_SIZE(test_paged_d_levels)];
+
+static rpmi_int32_t test_paged_l_levels[][3] = {
+	{ 1000000, 1100000, 50000 },
+	{ 1200000, 1300000, 50000 },
+	{ 1400000, 1500000, 50000 },
+	{ 1600000, 1700000, 50000 },
+};
+
+static rpmi_int32_t test_paged_l_buf[ARRAY_SIZE(test_paged_l_levels)]
+				    [ARRAY_SIZE(test_paged_l_levels[0])];
+
+static struct rpmi_voltage_discrete_range test_paged_d_range = {
+	.uvolt = (rpmi_uint32_t *)test_paged_d_levels,
+};
+
+static struct rpmi_voltage_linear_range test_paged_l_range = {
+	.uvolt_min = 1000000,
+	.uvolt_max = 1700000,
+	.uvolt_step = 50000,
+};
+
 static struct rpmi_voltage_data test_voltage_data[TEST_VOLT_COUNT] = {
 	[TEST_VOLT_CPU] = {
 		.name = "vdd_cpu",
@@ -67,22 +117,48 @@ static struct rpmi_voltage_data test_voltage_data[TEST_VOLT_COUNT] = {
 		.voltage_type = RPMI_VOLT_TYPE_LINEAR,
 		.control = RPMI_VOLT_CAPABILITY_ALWAYS_ON,
 		.config = RPMI_VOLT_CONFIG_NOT_SUPPORTED,
-		.num_levels = ARRAY_SIZE(test_mem_levels),
+		.num_levels = ARRAY_SIZE(test_mem_tuples),
 		.trans_latency = TEST_VOLT_MEM_LATENCY,
 		.linear_range = &test_mem_range,
-		.linear_levels = test_mem_levels,
+		.linear_levels = test_mem_tuples[0],
 		.level_uv = 1800000,
+	},
+	[TEST_VOLT_PAGED_D] = {
+		.name = "vdd_paged_d",
+		.voltage_type = RPMI_VOLT_TYPE_DISCRETE,
+		.control = RPMI_VOLT_CAPABILITY_ALWAYS_ON,
+		.config = RPMI_VOLT_CONFIG_NOT_SUPPORTED,
+		.num_levels = ARRAY_SIZE(test_paged_d_levels),
+		.trans_latency = TEST_VOLT_PAGED_LATENCY,
+		.discrete_range = &test_paged_d_range,
+		.discrete_levels = test_paged_d_buf,
+		.level_uv = 600000,
+	},
+	[TEST_VOLT_PAGED_L] = {
+		.name = "vdd_paged_l",
+		.voltage_type = RPMI_VOLT_TYPE_LINEAR,
+		.control = RPMI_VOLT_CAPABILITY_ALWAYS_ON,
+		.config = RPMI_VOLT_CONFIG_NOT_SUPPORTED,
+		.num_levels = ARRAY_SIZE(test_paged_l_levels),
+		.trans_latency = TEST_VOLT_PAGED_LATENCY,
+		.linear_range = &test_paged_l_range,
+		.linear_levels = test_paged_l_buf[0],
+		.level_uv = 1000000,
 	},
 };
 
 static rpmi_uint32_t test_current_config[TEST_VOLT_COUNT] = {
 	RPMI_VOLT_CONFIG_DISABLED,
 	RPMI_VOLT_CONFIG_NOT_SUPPORTED,
+	RPMI_VOLT_CONFIG_NOT_SUPPORTED,
+	RPMI_VOLT_CONFIG_NOT_SUPPORTED,
 };
 
 static rpmi_int32_t test_current_level[TEST_VOLT_COUNT] = {
 	TEST_VOLT_CPU_INITIAL,
 	1800000,
+	600000,
+	1000000,
 };
 
 static rpmi_uint32_t enable_notif_reqdata[] = {
@@ -126,9 +202,23 @@ static struct test_volt_attrs_expdata get_attrs_mem_expdata = {
 	.capability =
 		RPMI_VOLT_CAPABILITY_FORMAT(RPMI_VOLT_TYPE_LINEAR) |
 		RPMI_VOLT_CAPABILITY_CONTROL(RPMI_VOLT_CAPABILITY_ALWAYS_ON),
-	.num_levels = ARRAY_SIZE(test_mem_levels),
+	.num_levels = ARRAY_SIZE(test_mem_tuples),
 	.trans_latency = TEST_VOLT_MEM_LATENCY,
 	.name = "vdd_mem",
+};
+
+static rpmi_uint32_t volt_paged_l_reqdata[] = {
+	TEST_VOLT_PAGED_L,
+};
+
+static struct test_volt_attrs_expdata get_attrs_paged_l_expdata = {
+	.status = RPMI_SUCCESS,
+	.capability =
+		RPMI_VOLT_CAPABILITY_FORMAT(RPMI_VOLT_TYPE_LINEAR) |
+		RPMI_VOLT_CAPABILITY_CONTROL(RPMI_VOLT_CAPABILITY_ALWAYS_ON),
+	.num_levels = ARRAY_SIZE(test_paged_l_levels),
+	.trans_latency = TEST_VOLT_PAGED_LATENCY,
+	.name = "vdd_paged_l",
 };
 
 static rpmi_uint32_t invalid_param_expdata[] = {
@@ -154,13 +244,81 @@ static rpmi_uint32_t get_mem_levels_reqdata[] = {
 	0,
 };
 
+/* One tuple returned, none remaining, carrying all three of its words. */
 static rpmi_uint32_t get_mem_levels_expdata[] = {
 	RPMI_SUCCESS,
 	0,
 	0,
-	2,
+	ARRAY_SIZE(test_mem_tuples),
 	1800000,
 	1900000,
+	100000,
+};
+
+static rpmi_uint32_t get_paged_d_reqdata[] = {
+	TEST_VOLT_PAGED_D,
+	0,
+};
+
+/* The first call fills the message and leaves the rest for the next one. */
+static rpmi_uint32_t get_paged_d_expdata[] = {
+	RPMI_SUCCESS,
+	0,
+	ARRAY_SIZE(test_paged_d_levels) - TEST_VOLT_LEVELS_PER_MSG,
+	TEST_VOLT_LEVELS_PER_MSG,
+	600000,
+	625000,
+	650000,
+	675000,
+	700000,
+	725000,
+	750000,
+	775000,
+	800000,
+	825000,
+};
+
+static rpmi_uint32_t get_paged_d_rest_reqdata[] = {
+	TEST_VOLT_PAGED_D,
+	TEST_VOLT_LEVELS_PER_MSG,
+};
+
+static rpmi_uint32_t get_paged_d_rest_expdata[] = {
+	RPMI_SUCCESS,
+	0,
+	0,
+	ARRAY_SIZE(test_paged_d_levels) - TEST_VOLT_LEVELS_PER_MSG,
+	850000,
+	875000,
+};
+
+static rpmi_uint32_t get_paged_l_reqdata[] = {
+	TEST_VOLT_PAGED_L,
+	0,
+};
+
+/* Three tuples of three words each are all the message has room for. */
+static rpmi_uint32_t get_paged_l_expdata[] = {
+	RPMI_SUCCESS,
+	0,
+	ARRAY_SIZE(test_paged_l_levels) - TEST_VOLT_TUPLES_PER_MSG,
+	TEST_VOLT_TUPLES_PER_MSG,
+	1000000, 1100000, 50000,
+	1200000, 1300000, 50000,
+	1400000, 1500000, 50000,
+};
+
+static rpmi_uint32_t get_paged_l_rest_reqdata[] = {
+	TEST_VOLT_PAGED_L,
+	TEST_VOLT_TUPLES_PER_MSG,
+};
+
+static rpmi_uint32_t get_paged_l_rest_expdata[] = {
+	RPMI_SUCCESS,
+	0,
+	0,
+	ARRAY_SIZE(test_paged_l_levels) - TEST_VOLT_TUPLES_PER_MSG,
+	1600000, 1700000, 50000,
 };
 
 static rpmi_uint32_t get_invalid_levels_reqdata[] = {
@@ -239,9 +397,15 @@ static rpmi_bool_t test_voltage_level_supported(rpmi_uint32_t volt_id,
 	if (volt_id == TEST_VOLT_CPU) {
 		levels = test_cpu_levels;
 		count = ARRAY_SIZE(test_cpu_levels);
-	} else {
+	} else if (volt_id == TEST_VOLT_MEM) {
 		levels = test_mem_levels;
 		count = ARRAY_SIZE(test_mem_levels);
+	} else {
+		/*
+		 * The paged domains are only there to be read over several
+		 * calls, no level is ever set on them.
+		 */
+		return false;
 	}
 
 	for (i = 0; i < count; i++) {
@@ -285,17 +449,32 @@ static enum rpmi_error test_voltage_get_supp_levels(void *priv,
 						    rpmi_int32_t *level_array)
 {
 	rpmi_int32_t *src;
-	rpmi_uint32_t count, returned, i;
+	rpmi_uint32_t count, returned, i, words;
 
 	if (volt_id >= TEST_VOLT_COUNT || !returned_levels || !level_array)
 		return RPMI_ERR_INVALID_PARAM;
 
-	if (volt_id == TEST_VOLT_CPU) {
+	switch (volt_id) {
+	case TEST_VOLT_CPU:
 		src = test_cpu_levels;
 		count = ARRAY_SIZE(test_cpu_levels);
-	} else {
-		src = test_mem_levels;
-		count = ARRAY_SIZE(test_mem_levels);
+		words = 1;
+		break;
+	case TEST_VOLT_MEM:
+		src = test_mem_tuples[0];
+		count = ARRAY_SIZE(test_mem_tuples);
+		words = ARRAY_SIZE(test_mem_tuples[0]);
+		break;
+	case TEST_VOLT_PAGED_D:
+		src = test_paged_d_levels;
+		count = ARRAY_SIZE(test_paged_d_levels);
+		words = 1;
+		break;
+	default:
+		src = test_paged_l_levels[0];
+		count = ARRAY_SIZE(test_paged_l_levels);
+		words = ARRAY_SIZE(test_paged_l_levels[0]);
+		break;
 	}
 
 	if (volt_index >= count)
@@ -305,8 +484,8 @@ static enum rpmi_error test_voltage_get_supp_levels(void *priv,
 	if (returned > max)
 		returned = max;
 
-	for (i = 0; i < returned; i++)
-		level_array[i] = src[volt_index + i];
+	for (i = 0; i < returned * words; i++)
+		level_array[i] = src[(volt_index * words) + i];
 
 	*returned_levels = returned;
 	return RPMI_SUCCESS;
@@ -361,7 +540,7 @@ static struct rpmi_test_scenario scenario_voltage_default = {
 	.init = test_voltage_scenario_init,
 	.cleanup = test_scenario_default_cleanup,
 
-	.num_tests = 16,
+	.num_tests = 22,
 	.tests = {
 		{
 			.name = "ENABLE NOTIFICATION TEST (notifications not supported)",
@@ -417,6 +596,20 @@ static struct rpmi_test_scenario scenario_voltage_default = {
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
 		{
+			.name = "GET ATTRIBUTES (linear, multiple ranges)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
+				.service_id = RPMI_VOLT_SRV_GET_ATTRIBUTES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = volt_paged_l_reqdata,
+				.request_data_len = sizeof(volt_paged_l_reqdata),
+				.expected_data = &get_attrs_paged_l_expdata,
+				.expected_data_len = sizeof(get_attrs_paged_l_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
 			.name = "GET ATTRIBUTES (invalid domain)",
 			.attrs = {
 				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
@@ -426,6 +619,20 @@ static struct rpmi_test_scenario scenario_voltage_default = {
 				.request_data_len = sizeof(volt_invalid_reqdata),
 				.expected_data = invalid_param_expdata,
 				.expected_data_len = sizeof(invalid_param_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET ATTRIBUTES (valid query after an invalid one)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
+				.service_id = RPMI_VOLT_SRV_GET_ATTRIBUTES,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = volt_cpu_reqdata,
+				.request_data_len = sizeof(volt_cpu_reqdata),
+				.expected_data = &get_attrs_cpu_expdata,
+				.expected_data_len = sizeof(get_attrs_cpu_expdata),
 			},
 			.init_request_data = test_init_request_data_from_attrs,
 			.init_expected_data = test_init_expected_data_from_attrs,
@@ -454,6 +661,62 @@ static struct rpmi_test_scenario scenario_voltage_default = {
 				.request_data_len = sizeof(get_mem_levels_reqdata),
 				.expected_data = get_mem_levels_expdata,
 				.expected_data_len = sizeof(get_mem_levels_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET SUPPORTED LEVELS (discrete, first message)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
+				.service_id = RPMI_VOLT_SRV_GET_SUPPORTED_LEVELS,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_paged_d_reqdata,
+				.request_data_len = sizeof(get_paged_d_reqdata),
+				.expected_data = get_paged_d_expdata,
+				.expected_data_len = sizeof(get_paged_d_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET SUPPORTED LEVELS (discrete, remaining)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
+				.service_id = RPMI_VOLT_SRV_GET_SUPPORTED_LEVELS,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_paged_d_rest_reqdata,
+				.request_data_len = sizeof(get_paged_d_rest_reqdata),
+				.expected_data = get_paged_d_rest_expdata,
+				.expected_data_len = sizeof(get_paged_d_rest_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET SUPPORTED LEVELS (linear, first message)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
+				.service_id = RPMI_VOLT_SRV_GET_SUPPORTED_LEVELS,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_paged_l_reqdata,
+				.request_data_len = sizeof(get_paged_l_reqdata),
+				.expected_data = get_paged_l_expdata,
+				.expected_data_len = sizeof(get_paged_l_expdata),
+			},
+			.init_request_data = test_init_request_data_from_attrs,
+			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "GET SUPPORTED LEVELS (linear, remaining)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_VOLTAGE,
+				.service_id = RPMI_VOLT_SRV_GET_SUPPORTED_LEVELS,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.request_data = get_paged_l_rest_reqdata,
+				.request_data_len = sizeof(get_paged_l_rest_reqdata),
+				.expected_data = get_paged_l_rest_expdata,
+				.expected_data_len = sizeof(get_paged_l_rest_expdata),
 			},
 			.init_request_data = test_init_request_data_from_attrs,
 			.init_expected_data = test_init_expected_data_from_attrs,


### PR DESCRIPTION
This PR fixes two conformance bugs in the VOLTAGE service group (SERVICEGROUP_ID 0x0007) as specified in the RPMI specification, where the replies built by the library did not match the encoding the specification defines.

### Overview

The VOLTAGE service group lets a supervisor enumerate the voltage domains of a platform and read or change their levels. Two of its services built replies that a conforming client cannot use: a successful attributes query did not report its status, and the supported levels of a linear range domain were truncated to a third of their width. Both are in the reply framing, which the library owns, so a platform implementation cannot work around either of them.

### Changes

1. Library implementation (lib/rpmi_service_group_voltage.c) — fixes 2 of the 8 services defined for the group.

VOLT_GET_ATTRIBUTES (0x03) — rpmi_volt_get_attributes() fills in the capability, level count, transition latency and domain name of a successful reply, but writes resp[0] only on its error paths, unlike every other service in the group. On success the status word keeps whatever the previous response left in the buffer, so a valid query can report an error while carrying correct attributes. To reproduce: query an invalid domain, then a valid one — the second reply carries the RPMI_ERR_INVALID_PARAM of the first.

VOLT_GET_SUPPORTED_LEVELS (0x04) — the spec types VOLTAGE_LEVEL[] as uint32 or uint32[3], and says NUM_LEVELS/RETURNED/REMAINING count levels, each linear range counting as one. The reply was packed as one word per level regardless of format, so a linear domain returned only its voltage_min. Fixed by deriving the width of a level from the advertised format and applying it to the copy loop, response_datalen, and the message capacity (which counted words rather than levels).

2. Tests (test/test_srvgrp_voltage.c) — fixes the linear test domain, which was declared with a two-word level array and num_levels = ARRAY_SIZE(), so correct packing walked off the end of it into the neighbouring discrete table; counts and indexes its levels in tuples; validates a linear level against its range; updates the expected reply to the full tuple; and adds a regression test for the status bug.

### Testing

- [x]  make — builds successfully without warnings

- [x] make LIBRPMI_TEST=y — builds with tests successfully

- [x]  make LIBRPMI_TEST=y check — all tests pass, 134 total, 17 in the voltage service group

Each fix is covered by a test that fails without it.

Compliance — brings VOLT_GET_ATTRIBUTES and VOLT_GET_SUPPORTED_LEVELS into line with the VOLTAGE service group as specified in the RISC-V RPMI specification.