### PR TITLE
bug: cppc: replace undefined fallthrough with comment

### DIFF
--- a/lib/rpmi_service_group_cppc.c
+++ b/lib/rpmi_service_group_cppc.c
@@ -422,7 +422,7 @@ static enum rpmi_error __rpmi_cppc_write_reg(struct rpmi_cppc_group *cppcgrp,
 		if (reg_id == RPMI_CPPC_AUTONOMOUS_SELECTION_ENABLE)
 			cppcgrp->autonomous_selection_enable =
 				(rpmi_uint32_t)reg_val;
-		fallthrough;
+		/* fallthrough */
 	case RPMI_CPPC_AUTONOMOUS_ACTIVITY_WINDOW:
 	case RPMI_CPPC_ENERGY_PERF_PREFERENCE:
 	case RPMI_CPPC_TIME_WINDOW:


### PR DESCRIPTION
## Summary

Previously merged [PR](https://github.com/riscv-software-src/librpmi/pull/115), introduce a compilation issue
`__rpmi_cppc_write_reg()` in `lib/rpmi_service_group_cppc.c` used a bare
`fallthrough;` statement.

lib/rpmi_service_group_cppc.c:425:3: error: 'fallthrough' undeclared (first use in this function)
fallthrough;
^~~~~~~~~~~

## Fix

Replace the statement with a `/* fallthrough */` comment. GCC's
`-Wimplicit-fallthrough` (enabled by `-Wall`) recognizes this comment
form and allows the intentional case fall-through without warning, so
the switch behavior is unchanged.

## Testing

- [x] make - builds successfully without warnings
- [x] make check - all tests pass
- [x] make LIBRPMI_TEST=y - builds with tests successfully
- [x] make docs - builds successfully

## Compliance
This compliance matrix tracks implementation status as specified in the RISC-V RPMI specification v1.0 and v2.0 (draft).