### PR TITLE
cppc: advertise optional fast-channel doorbell (follow-up to autonomous mode)

### DIFF
--- a/include/librpmi.h
+++ b/include/librpmi.h
@@ -1438,6 +1438,26 @@ enum rpmi_cppc_mode {
 /**
  * ACPI CPPC Registers
  */
+/** CPPC fastchannel flags */
+#define RPMI_CPPC_FST_CHN_DB_REG_08_BITS	(0U << 1)
+#define RPMI_CPPC_FST_CHN_DB_REG_16_BITS	(1U << 1)
+#define RPMI_CPPC_FST_CHN_DB_REG_32_BITS	(2U << 1)
+
+#define RPMI_CPPC_FST_CHN_DB_NOT_SUPP		(0U << 0)
+#define RPMI_CPPC_FST_CHN_DB_SUPP		(1U << 0)
+
+/** CPPC Perf Request fast-channel doorbell */
+struct rpmi_cppc_fastchan_doorbell {
+	/** doorbell flags */
+	rpmi_uint32_t flags;
+	/** doorbell addr low */
+	rpmi_uint32_t db_addr_low;
+	/** doorbell addr high */
+	rpmi_uint32_t db_addr_high;
+	/** doorbell write value */
+	rpmi_uint32_t db_write_value;
+};
+
 struct rpmi_cppc_regs {
 	/* highest performance (r) */
 	rpmi_uint32_t highest_perf;
@@ -1483,6 +1503,8 @@ struct rpmi_cppc_regs {
 	rpmi_uint32_t nominal_freq;
 	/* transition latency */
 	rpmi_uint32_t transition_latency;
+	/* Perf Request fast-channel doorbell (optional) */
+	struct rpmi_cppc_fastchan_doorbell doorbell;
 };
 
 /* CPPC Fastchannel size of both types as per RPMI spec */

--- a/lib/rpmi_service_group_cppc.c
+++ b/lib/rpmi_service_group_cppc.c
@@ -637,36 +637,50 @@ rpmi_cppc_sg_get_fast_channel_region(struct rpmi_service_group *group,
 	rpmi_uint32_t resp_dlen, flags;
 	rpmi_uint64_t fastchan_region_base, fastchan_region_size;
 	struct rpmi_cppc_group *cppcgrp = group->priv;
+	struct rpmi_cppc_fastchan *fc = cppcgrp->fastchan_ctx;
+	const struct rpmi_cppc_fastchan_doorbell *db = &cppcgrp->regs->doorbell;
 	rpmi_uint32_t *resp = (void *)response_data;
 
-	if (!cppcgrp->fastchan_ctx) {
+	if (!fc) {
 		status = RPMI_ERR_NOTSUPP;
 		resp_dlen = sizeof(*resp);
 		goto done;
 	}
 
-	fastchan_region_base = rpmi_shmem_base(cppcgrp->fastchan_ctx->shmem);
-	fastchan_region_size = rpmi_shmem_size(cppcgrp->fastchan_ctx->shmem);
+	fastchan_region_base = rpmi_shmem_base(fc->shmem);
+	fastchan_region_size = rpmi_shmem_size(fc->shmem);
 
-	/* FLAGS[4:3]: 0b00 = normal/passive, 0b01 = autonomous. No doorbell. */
+	/* FLAGS[4:3]: 0b00 = normal/passive, 0b01 = autonomous. */
 	flags = (cppcgrp->cppc_mode == RPMI_CPPC_AUTO_MODE) ? (0x01U << 3) : 0;
+
+	/* FLAGS[2:1] doorbell width, FLAGS[0] doorbell support (optional) */
+	if (db->flags & RPMI_CPPC_FST_CHN_DB_SUPP) {
+		flags |= RPMI_CPPC_FST_CHN_DB_SUPP | (db->flags & (0x3U << 1));
+		/* doorbell addr low */
+		resp[6] = rpmi_to_xe32(trans->is_be, db->db_addr_low);
+		/* doorbell addr high */
+		resp[7] = rpmi_to_xe32(trans->is_be, db->db_addr_high);
+		/* doorbell write value */
+		resp[8] = rpmi_to_xe32(trans->is_be, db->db_write_value);
+	} else {
+		/* doorbell addr low */
+		resp[6] = 0;
+		/* doorbell addr high */
+		resp[7] = 0;
+		/* doorbell write value */
+		resp[8] = 0;
+	}
 
 	status = RPMI_SUCCESS;
 	resp[1] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)flags);
 	/* fast channel region address low */
 	resp[2] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)fastchan_region_base);
-	/* fast channel region address low */
+	/* fast channel region address high */
 	resp[3] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)(fastchan_region_base >> 32));
 	/* fast channel region size low */
-	resp[4] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)fastchan_region_size);;
+	resp[4] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)fastchan_region_size);
 	/* fast channel region size high */
 	resp[5] = rpmi_to_xe32(trans->is_be, (rpmi_uint32_t)(fastchan_region_size >> 32));
-	/* doorbell addr low */
-	resp[6] = 0;
-	/* doorbell addr high */
-	resp[7] = 0;
-	/* doorbell write value */
-	resp[8] = 0;
 
 	resp_dlen = 9 * sizeof(*resp);
 

--- a/test/test_srvgrp_cppc.c
+++ b/test/test_srvgrp_cppc.c
@@ -29,6 +29,14 @@
 #define TEST_CPPC_AUTO_MIN_PERF			0x20
 #define TEST_CPPC_AUTO_MAX_PERF			0x40
 
+/* Doorbell scenario: passive mode + 32-bit doorbell */
+#define TEST_CPPC_DB_ADDR_LOW			0x30000000
+#define TEST_CPPC_DB_ADDR_HIGH			0x0
+#define TEST_CPPC_DB_WRITE_VALUE		0x7
+/* FLAGS[2:1]=0b10 (32-bit) | FLAGS[0]=1 (doorbell supported) */
+#define TEST_CPPC_DB_FLAGS			(RPMI_CPPC_FST_CHN_DB_REG_32_BITS | \
+						 RPMI_CPPC_FST_CHN_DB_SUPP)
+
 static rpmi_uint32_t test_auto_captured_min_perf;
 static rpmi_uint32_t test_auto_captured_max_perf;
 
@@ -880,7 +888,7 @@ static struct rpmi_test_scenario scenario_cppc_s_mode = {
 	.init = test_cppc_auto_scenario_init,
 	.cleanup = test_scenario_default_cleanup,
 
-	.num_tests = 4,
+	.num_tests = 5,
 	.tests = {
 		{
 			.name = "PROBE HIGHEST_PERF (S-mode access)",
@@ -938,6 +946,239 @@ static struct rpmi_test_scenario scenario_cppc_s_mode = {
 			.init_request_data = test_init_request_data_from_attrs,
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
+		{
+			.name = "GET FAST CHANNEL REGION (S-mode access)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_GET_FAST_CHANNEL_REGION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+			},
+			.init_expected_data = init_auto_fastchan_region_expected,
+		},
+	},
+};
+
+/* ---- Doorbell scenario (passive mode + fast-channel doorbell) ------------ */
+
+static rpmi_uint8_t test_db_fastchan_mem[TEST_CPPC_FASTCHAN_SIZE]
+	__aligned(RPMI_CPPC_FASTCHAN_SIZE);
+
+/* Same as test_cppc_regs, but with a fast-channel doorbell embedded */
+static struct rpmi_cppc_regs test_cppc_db_regs = {
+	.highest_perf = TEST_CPPC_HIGHEST_PERF,
+	.nominal_perf = TEST_CPPC_NOMINAL_PERF,
+	.lowest_nonlinear_perf = 0x30,
+	.lowest_perf = 0x10,
+	.reference_perf = TEST_CPPC_NOMINAL_PERF,
+	.lowest_freq = 1000000000U,
+	.nominal_freq = 2000000000U,
+	.transition_latency = 10,
+	.doorbell = {
+		.flags = TEST_CPPC_DB_FLAGS,
+		.db_addr_low = TEST_CPPC_DB_ADDR_LOW,
+		.db_addr_high = TEST_CPPC_DB_ADDR_HIGH,
+		.db_write_value = TEST_CPPC_DB_WRITE_VALUE,
+	},
+};
+
+static rpmi_uint16_t init_db_fastchan_region_expected(struct rpmi_test_scenario *scene,
+						      struct rpmi_test *test,
+						      void *data,
+						      rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *exp = data;
+	rpmi_uint64_t base = (rpmi_uint64_t)(rpmi_uintptr_t)test_db_fastchan_mem;
+
+	exp[0] = RPMI_SUCCESS;
+	/* passive mode (FLAGS[4:3]=0) + 32-bit doorbell support */
+	exp[1] = TEST_CPPC_DB_FLAGS;
+	exp[2] = (rpmi_uint32_t)base;
+	exp[3] = (rpmi_uint32_t)(base >> 32);
+	exp[4] = TEST_CPPC_FASTCHAN_SIZE;
+	exp[5] = 0;
+	exp[6] = TEST_CPPC_DB_ADDR_LOW;
+	exp[7] = TEST_CPPC_DB_ADDR_HIGH;
+	exp[8] = TEST_CPPC_DB_WRITE_VALUE;
+
+	return 9 * sizeof(*exp);
+}
+
+static int test_cppc_db_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct rpmi_service_group *grp;
+	struct rpmi_shmem *fastchan_shmem;
+	struct rpmi_hsm *hsm;
+	int ret;
+
+	ret = test_cppc_scene_base_init(scene);
+	if (ret)
+		return RPMI_ERR_FAILED;
+
+	hsm = rpmi_hsm_create(ARRAY_SIZE(test_hartid_array),
+			      test_hartid_array, 0, NULL, &test_hsm_ops, NULL);
+	if (!hsm) {
+		printf("failed to create rpmi hsm");
+		return RPMI_ERR_FAILED;
+	}
+
+	fastchan_shmem = rpmi_shmem_create("test_cppc_db_fastchan",
+					   (rpmi_uint64_t)(rpmi_uintptr_t)test_db_fastchan_mem,
+					   sizeof(test_db_fastchan_mem),
+					   &rpmi_shmem_simple_ops, NULL);
+	if (!fastchan_shmem) {
+		printf("failed to create cppc doorbell fastchannel shmem");
+		return RPMI_ERR_FAILED;
+	}
+
+	grp = rpmi_service_group_cppc_create(hsm, &test_cppc_db_regs,
+					     RPMI_CPPC_PASSIVE_MODE,
+					     fastchan_shmem,
+					     TEST_CPPC_FASTCHAN_REQ_OFFSET,
+					     TEST_CPPC_FASTCHAN_FB_OFFSET,
+					     &test_cppc_ops, NULL);
+	if (!grp) {
+		printf("failed to create rpmi cppc doorbell service group");
+		return RPMI_ERR_FAILED;
+	}
+
+	rpmi_context_add_group(scene->cntx, grp);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_cppc_doorbell = {
+	.name = "CPPC Service Group (Fast-channel Doorbell)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &cppc_m_mode_config,
+
+	.init = test_cppc_db_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 1,
+	.tests = {
+		{
+			.name = "GET FAST CHANNEL REGION (doorbell advertised)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_GET_FAST_CHANNEL_REGION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+			},
+			.init_expected_data = init_db_fastchan_region_expected,
+		},
+	},
+};
+
+/* ---- Autonomous mode + doorbell scenario (combined FLAGS) ---------------- */
+
+static rpmi_uint8_t test_auto_db_fastchan_mem[TEST_CPPC_FASTCHAN_SIZE]
+	__aligned(RPMI_CPPC_FASTCHAN_SIZE);
+
+/* Autonomous regs with a fast-channel doorbell embedded */
+static struct rpmi_cppc_regs test_cppc_auto_db_regs = {
+	.highest_perf = TEST_CPPC_HIGHEST_PERF,
+	.nominal_perf = TEST_CPPC_NOMINAL_PERF,
+	.lowest_nonlinear_perf = 0x30,
+	.lowest_perf = 0x10,
+	.guaranteed_perf = TEST_CPPC_GUARANTEED_PERF,
+	.reference_perf = TEST_CPPC_NOMINAL_PERF,
+	.lowest_freq = 1000000000U,
+	.nominal_freq = 2000000000U,
+	.transition_latency = 10,
+	.autonomous_selection_enable = 1,
+	.doorbell = {
+		.flags = TEST_CPPC_DB_FLAGS,
+		.db_addr_low = TEST_CPPC_DB_ADDR_LOW,
+		.db_addr_high = TEST_CPPC_DB_ADDR_HIGH,
+		.db_write_value = TEST_CPPC_DB_WRITE_VALUE,
+	},
+};
+
+static rpmi_uint16_t init_auto_db_fastchan_region_expected(struct rpmi_test_scenario *scene,
+							   struct rpmi_test *test,
+							   void *data,
+							   rpmi_uint16_t max_data_len)
+{
+	rpmi_uint32_t *exp = data;
+	rpmi_uint64_t base = (rpmi_uint64_t)(rpmi_uintptr_t)test_auto_db_fastchan_mem;
+
+	exp[0] = RPMI_SUCCESS;
+	/* autonomous mode (FLAGS[4:3]) combined with 32-bit doorbell support */
+	exp[1] = TEST_CPPC_AUTO_FLAGS | TEST_CPPC_DB_FLAGS;
+	exp[2] = (rpmi_uint32_t)base;
+	exp[3] = (rpmi_uint32_t)(base >> 32);
+	exp[4] = TEST_CPPC_FASTCHAN_SIZE;
+	exp[5] = 0;
+	exp[6] = TEST_CPPC_DB_ADDR_LOW;
+	exp[7] = TEST_CPPC_DB_ADDR_HIGH;
+	exp[8] = TEST_CPPC_DB_WRITE_VALUE;
+
+	return 9 * sizeof(*exp);
+}
+
+static int test_cppc_auto_db_scenario_init(struct rpmi_test_scenario *scene)
+{
+	struct rpmi_service_group *grp;
+	struct rpmi_shmem *fastchan_shmem;
+	struct rpmi_hsm *hsm;
+	int ret;
+
+	ret = test_cppc_scene_base_init(scene);
+	if (ret)
+		return RPMI_ERR_FAILED;
+
+	hsm = rpmi_hsm_create(ARRAY_SIZE(test_hartid_array),
+			      test_hartid_array, 0, NULL, &test_hsm_ops, NULL);
+	if (!hsm) {
+		printf("failed to create rpmi hsm");
+		return RPMI_ERR_FAILED;
+	}
+
+	fastchan_shmem = rpmi_shmem_create("test_cppc_auto_db_fastchan",
+					   (rpmi_uint64_t)(rpmi_uintptr_t)test_auto_db_fastchan_mem,
+					   sizeof(test_auto_db_fastchan_mem),
+					   &rpmi_shmem_simple_ops, NULL);
+	if (!fastchan_shmem) {
+		printf("failed to create cppc auto doorbell fastchannel shmem");
+		return RPMI_ERR_FAILED;
+	}
+
+	grp = rpmi_service_group_cppc_create(hsm, &test_cppc_auto_db_regs,
+					     RPMI_CPPC_AUTO_MODE,
+					     fastchan_shmem,
+					     TEST_CPPC_FASTCHAN_REQ_OFFSET,
+					     TEST_CPPC_FASTCHAN_FB_OFFSET,
+					     &test_cppc_ops, NULL);
+	if (!grp) {
+		printf("failed to create rpmi cppc auto doorbell service group");
+		return RPMI_ERR_FAILED;
+	}
+
+	rpmi_context_add_group(scene->cntx, grp);
+	return 0;
+}
+
+static struct rpmi_test_scenario scenario_cppc_auto_doorbell = {
+	.name = "CPPC Service Group (Autonomous Mode + Doorbell)",
+	.shm_size = RPMI_SHM_SZ,
+	.slot_size = RPMI_SLOT_SIZE,
+	.max_num_groups = RPMI_SRVGRP_ID_MAX_COUNT,
+	.priv = &cppc_m_mode_config,
+
+	.init = test_cppc_auto_db_scenario_init,
+	.cleanup = test_scenario_default_cleanup,
+
+	.num_tests = 1,
+	.tests = {
+		{
+			.name = "GET FAST CHANNEL REGION (auto mode + doorbell)",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_CPPC,
+				.service_id = RPMI_CPPC_SRV_GET_FAST_CHANNEL_REGION,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+			},
+			.init_expected_data = init_auto_db_fastchan_region_expected,
+		},
 	},
 };
 
@@ -949,5 +1190,7 @@ int main(int argc, char *argv[])
 	ret |= test_scenario_execute(&scenario_cppc_default);
 	ret |= test_scenario_execute(&scenario_cppc_auto);
 	ret |= test_scenario_execute(&scenario_cppc_s_mode);
+	ret |= test_scenario_execute(&scenario_cppc_doorbell);
+	ret |= test_scenario_execute(&scenario_cppc_auto_doorbell);
 	return ret;
 }


### PR DESCRIPTION
This is a follow-up to the previous [PR](https://github.com/riscv-software-src/librpmi/pull/115) that added CPPC autonomous mode. While wiring up `GET_FAST_CHANNEL_REGION` for autonomous mode, one commit was forgotten. The optional fast-channel doorbell that the same service advertise, this PR fills that gap.

Until now librpmi hardcoded these fields to zero, so even with the rest of the fast-channel path in place a platform had no way to advertise a doorbell.

The doorbell lets the application processor signal the platform microcontroller
after updating its Perf Request fast-channel, instead of relying on polling. It
is described by:

librpmi was still hardcoding these fields to zero, so a platform could never advertise a doorbell even though the rest of the fast-channel path was in place.

## Tests

Added test coverage for:
- Doorbell advertisement in passive mode (32-bit doorbell)
- Doorbell advertisement in autonomous mode (combined `FLAGS[4:3]` + doorbell bits)
- S-mode access to `GET_FAST_CHANNEL_REGION`
